### PR TITLE
Refactor: separate JS and Flask logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,58 +1,22 @@
-import csv
-import io
 import os
-import asyncio
-from flask import Flask, render_template, request, jsonify
-import pandas as pd
-import openai
-import openai
+from flask import Flask
 from dotenv import load_dotenv
+import openai
 
-load_dotenv()  # 👈 this makes FLASK_ENV and others available
-
+load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
-app = Flask(__name__)
 
-# In-memory storage for uploaded data
-DATAFRAME = None
+def create_app():
+    app = Flask(__name__)
 
-@app.route('/')
-def index():
-    return render_template('index.html')
+    from routes import bp as main_bp
+    app.register_blueprint(main_bp)
 
-@app.route('/upload', methods=['POST'])
-def upload():
-    global DATAFRAME
-    csv_text = ''
+    return app
 
-    if 'csv_file' in request.files and request.files['csv_file']:
-        file = request.files['csv_file']
-        csv_text = file.read().decode('utf-8')
-    elif 'csv_text' in request.form and request.form['csv_text'].strip():
-        csv_text = request.form['csv_text']
-    else:
-        return 'No CSV data provided', 400
-
-    f = io.StringIO(csv_text)
-    DATAFRAME = pd.read_csv(f)
-    return DATAFRAME.to_json(orient='records')
-
-@app.route('/process', methods=['POST'])
-def process():
-    global DATAFRAME
-    prompt = request.json.get('prompt', '')
-
-    # Simple fake logic: apply prompt formatting to each row
-    processed = []
-    for _, row in DATAFRAME.iterrows():
-        try:
-            result = prompt.format(**row)
-        except KeyError as e:
-            result = f"Missing column: {e}"
-        processed.append({**row.to_dict(), 'result': result})
-
-    return jsonify(processed)
 
 if __name__ == '__main__':
+    app = create_app()
     app.run(debug=True, host='0.0.0.0', port=5000)
+

--- a/processing.py
+++ b/processing.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+
+def apply_prompt_to_dataframe(df: pd.DataFrame, prompt: str):
+    """Apply the prompt to each row of the dataframe and return results."""
+    processed = []
+    for _, row in df.iterrows():
+        try:
+            result = prompt.format(**row)
+        except KeyError as e:
+            result = f"Missing column: {e}"
+        processed.append({**row.to_dict(), 'result': result})
+    return processed
+

--- a/routes.py
+++ b/routes.py
@@ -1,0 +1,42 @@
+import io
+import pandas as pd
+from flask import Blueprint, render_template, request, jsonify
+
+from processing import apply_prompt_to_dataframe
+
+bp = Blueprint('main', __name__)
+
+# In-memory storage for uploaded data
+DATAFRAME = None
+
+
+@bp.route('/')
+def index():
+    return render_template('index.html')
+
+
+@bp.route('/upload', methods=['POST'])
+def upload():
+    global DATAFRAME
+    csv_text = ''
+
+    if 'csv_file' in request.files and request.files['csv_file']:
+        file = request.files['csv_file']
+        csv_text = file.read().decode('utf-8')
+    elif 'csv_text' in request.form and request.form['csv_text'].strip():
+        csv_text = request.form['csv_text']
+    else:
+        return 'No CSV data provided', 400
+
+    f = io.StringIO(csv_text)
+    DATAFRAME = pd.read_csv(f)
+    return DATAFRAME.to_json(orient='records')
+
+
+@bp.route('/process', methods=['POST'])
+def process():
+    global DATAFRAME
+    prompt = request.json.get('prompt', '')
+    results = apply_prompt_to_dataframe(DATAFRAME, prompt)
+    return jsonify(results)
+

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,46 @@
+$('#upload-form').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    $.ajax({
+        url: '/upload',
+        method: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function(data){
+            renderTable(JSON.parse(data));
+            $('#process-section').show();
+        },
+        error: function(xhr){ alert(xhr.responseText); }
+    });
+});
+
+function renderTable(data){
+    if(!data.length){ $('#table-container').html('No rows'); return; }
+    var html = '<table><thead><tr>';
+    Object.keys(data[0]).forEach(function(col){ html += '<th>'+col+'</th>'; });
+    html += '</tr></thead><tbody>';
+    data.forEach(function(row){
+        html += '<tr>';
+        Object.values(row).forEach(function(val){ html += '<td>'+val+'</td>'; });
+        html += '</tr>';
+    });
+    html += '</tbody></table>';
+    $('#table-container').html(html);
+}
+
+$('#process-btn').on('click', function(){
+    var prompt = $('#prompt').val();
+    $.ajax({
+        url: '/process',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({prompt: prompt}),
+        success: function(data){
+            console.log("Raw data from backend:", data);
+            renderTable(data);
+        },
+        error: function(xhr){ alert(xhr.responseText); }
+    });
+});
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,52 +28,6 @@
     <button id="process-btn">Process with ChatGPT</button>
 </div>
 
-<script>
-$('#upload-form').on('submit', function(e){
-    e.preventDefault();
-    var formData = new FormData(this);
-    $.ajax({
-        url: '/upload',
-        method: 'POST',
-        data: formData,
-        processData: false,
-        contentType: false,
-        success: function(data){
-            renderTable(JSON.parse(data));
-            $('#process-section').show();
-        },
-        error: function(xhr){ alert(xhr.responseText); }
-    });
-});
-
-function renderTable(data){
-    if(!data.length){ $('#table-container').html('No rows'); return; }
-    var html = '<table><thead><tr>';
-    Object.keys(data[0]).forEach(function(col){ html += '<th>'+col+'</th>'; });
-    html += '</tr></thead><tbody>';
-    data.forEach(function(row){
-        html += '<tr>';
-        Object.values(row).forEach(function(val){ html += '<td>'+val+'</td>'; });
-        html += '</tr>';
-    });
-    html += '</tbody></table>';
-    $('#table-container').html(html);
-}
-
-$('#process-btn').on('click', function(){
-    var prompt = $('#prompt').val();
-    $.ajax({
-        url: '/process',
-        method: 'POST',
-        contentType: 'application/json',
-        data: JSON.stringify({prompt: prompt}),
-        success: function(data){
-            console.log("Raw data from backend:", data);
-            renderTable(data);
-        },
-        error: function(xhr){ alert(xhr.responseText); }
-    });
-});
-</script>
+<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move JS from template to `static/js/main.js`
- split route handling to `routes.py`
- put processing code in `processing.py`
- make `app.py` create the Flask app and register routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app.py` *(started server and confirmed startup)*

------
https://chatgpt.com/codex/tasks/task_e_687a4ddb653c833380a65ca04927802e