### PR TITLE
Organize UI steps and show GPT results separately

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,14 +1,46 @@
 function loadSavedSetup(){
-    $('#saved-tsv').val(localStorage.getItem('saved_tsv') || '');
-    $('#saved-instructions').val(localStorage.getItem('saved_instructions') || '');
-    $('#saved-prompt').val(localStorage.getItem('saved_prompt') || '');
-    if($('#saved-tsv').val() || $('#saved-instructions').val() || $('#saved-prompt').val()){
+    const savedTsv = localStorage.getItem('saved_tsv') || '';
+    const savedInstructions = localStorage.getItem('saved_instructions') || '';
+    const savedPrompt = localStorage.getItem('saved_prompt') || '';
+
+    $('#saved-tsv').val(savedTsv);
+    $('#saved-instructions').val(savedInstructions);
+    $('#saved-prompt').val(savedPrompt);
+
+    if(savedTsv || savedInstructions || savedPrompt){
         $('#past-section').show();
+    }
+
+    return {savedTsv, savedInstructions, savedPrompt};
+}
+
+function autoPopulateFromSaved(){
+    const setup = loadSavedSetup();
+    if(setup.savedTsv || setup.savedInstructions || setup.savedPrompt){
+        $('#tsv-input').val(setup.savedTsv);
+        $('#instructions').val(setup.savedInstructions);
+        $('#prompt').val(setup.savedPrompt);
+
+        if(setup.savedTsv){
+            const formData = new FormData();
+            formData.append('tsv_text', setup.savedTsv);
+            $.ajax({
+                url: '/upload',
+                method: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: function(data){
+                    renderDataTable(JSON.parse(data));
+                },
+                error: function(xhr){ console.error(xhr.responseText); }
+            });
+        }
     }
 }
 
 $(document).ready(function(){
-    loadSavedSetup();
+    autoPopulateFromSaved();
 });
 
 $('#upload-form').on('submit', function(e){

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -22,7 +22,6 @@ $('#upload-form').on('submit', function(e){
         contentType: false,
         success: function(data){
             renderDataTable(JSON.parse(data));
-            $('#step2').show();
         },
         error: function(xhr){ alert(xhr.responseText); }
     });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -21,8 +21,8 @@ $('#upload-form').on('submit', function(e){
         processData: false,
         contentType: false,
         success: function(data){
-            renderTable(JSON.parse(data));
-            $('#process-section').show();
+            renderDataTable(JSON.parse(data));
+            $('#step2').show();
         },
         error: function(xhr){ alert(xhr.responseText); }
     });
@@ -47,7 +47,7 @@ $('#saved-tsv, #saved-instructions, #saved-prompt').on('change', function(){
     localStorage.setItem('saved_prompt', $('#saved-prompt').val());
 });
 
-function renderTable(data){
+function renderDataTable(data){
     if(!data.length){ $('#table-container').html('No rows'); return; }
     var html = '<table><thead><tr>';
     Object.keys(data[0]).forEach(function(col){ html += '<th>'+col+'</th>'; });
@@ -61,6 +61,36 @@ function renderTable(data){
     $('#table-container').html(html);
 }
 
+function renderResultsTable(data){
+    if(!data.length){ $('#results-container').html('No results'); return; }
+    var html = '<table><thead><tr>';
+    Object.keys(data[0]).forEach(function(col){ html += '<th>'+col+'</th>'; });
+    html += '</tr></thead><tbody>';
+    data.forEach(function(row){
+        html += '<tr>';
+        Object.values(row).forEach(function(val){ html += '<td>'+val+'</td>'; });
+        html += '</tr>';
+    });
+    html += '</tbody></table>';
+    $('#results-container').html(html);
+}
+
+function addOrUpdateResultRow(rowData, index){
+    var $table = $('#results-container table');
+    if(!$table.length){
+        renderResultsTable([rowData]);
+        return;
+    }
+    var keys = Object.keys(rowData);
+    var rowHtml = '<tr>' + keys.map(function(k){ return '<td>'+rowData[k]+'</td>'; }).join('') + '</tr>';
+    var $rows = $table.find('tbody tr');
+    if(index < $rows.length){
+        $rows.eq(index).replaceWith(rowHtml);
+    } else {
+        $table.find('tbody').append(rowHtml);
+    }
+}
+
 $('#process-btn').on('click', function(){
     var prompt = $('#prompt').val();
     var instructions = $('#instructions').val();
@@ -71,7 +101,7 @@ $('#process-btn').on('click', function(){
         data: JSON.stringify({prompt: prompt, instructions: instructions}),
         success: function(data){
             console.log("Raw data from backend:", data);
-            renderTable(data);
+            renderResultsTable(data);
         },
         error: function(xhr){ alert(xhr.responseText); }
     });
@@ -87,19 +117,7 @@ $('#process-single-btn').on('click', function(){
         contentType: 'application/json',
         data: JSON.stringify({prompt: prompt, instructions: instructions, row_index: rowIndex}),
         success: function(data){
-            var $table = $('#table-container table');
-            if($table.length){
-                var $rows = $table.find('tbody tr');
-                if($table.find('th.result-column').length === 0){
-                    $table.find('thead tr').append('<th class="result-column">result</th>');
-                    $rows.each(function(){ $(this).append('<td></td>'); });
-                }
-                if(rowIndex < $rows.length){
-                    $rows.eq(rowIndex).find('td').last().text(data.result);
-                }
-            } else {
-                alert('Result: ' + data.result);
-            }
+            addOrUpdateResultRow(data, rowIndex);
         },
         error: function(xhr){ alert(xhr.responseText); }
     });

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
     <div id="table-container"></div>
 </div>
 
-<div id="step2" style="display:none; margin-top:2em;">
+<div id="step2" style="margin-top:2em;">
     <h2>STEP 2: Generate Contacts</h2>
     <div id="process-section">
         <label>Instructions:</label><br>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,35 +12,47 @@
 </head>
 <body>
 <h1>SFA Lead Generator</h1>
-<form id="upload-form" method="post" enctype="multipart/form-data">
-    <label>Paste TSV Data:</label><br>
-    <textarea name="tsv_text" id="tsv-input"></textarea><br>
-    <button type="submit">Load Data</button>
-    <button type="button" id="save-setup-btn">Save Setup</button>
-</form>
 
-<div id="past-section" style="display:none; margin-top:1em;">
-    <h3>Saved Setup</h3>
-    <label>TSV Input:</label><br>
-    <textarea id="saved-tsv"></textarea><br>
-    <label>Instructions:</label><br>
-    <textarea id="saved-instructions" style="height:80px;"></textarea><br>
-    <label>Prompt:</label><br>
-    <input type="text" id="saved-prompt" style="width:100%;"><br>
-    <button type="button" id="load-setup-btn">Load Saved Setup</button>
+<div id="step1">
+    <h2>STEP 1: Initial Data Load</h2>
+    <form id="upload-form" method="post" enctype="multipart/form-data">
+        <label>Paste TSV Data:</label><br>
+        <textarea name="tsv_text" id="tsv-input"></textarea><br>
+        <button type="submit">Load Data</button>
+        <button type="button" id="save-setup-btn">Save Setup</button>
+    </form>
+
+    <div id="past-section" style="display:none; margin-top:1em;">
+        <h3>Saved Setup</h3>
+        <label>TSV Input:</label><br>
+        <textarea id="saved-tsv"></textarea><br>
+        <label>Instructions:</label><br>
+        <textarea id="saved-instructions" style="height:80px;"></textarea><br>
+        <label>Prompt:</label><br>
+        <input type="text" id="saved-prompt" style="width:100%;"><br>
+        <button type="button" id="load-setup-btn">Load Saved Setup</button>
+    </div>
+
+    <div id="table-container"></div>
 </div>
 
-<div id="table-container"></div>
+<div id="step2" style="display:none; margin-top:2em;">
+    <h2>STEP 2: Generate Contacts</h2>
+    <div id="process-section">
+        <label>Instructions:</label><br>
+        <textarea id="instructions" style="height:80px;"></textarea><br>
+        <label>Prompt (use column names in {braces}):</label><br>
+        <input type="text" id="prompt" style="width:100%;" placeholder="e.g. Summarize {name}"><br>
+        <label>Row index for single run:</label>
+        <input type="number" id="row-index" value="0" min="0"><br>
+        <button id="process-single-btn">Process Single Row</button>
+        <button id="process-btn">Process All Rows</button>
+    </div>
+    <div id="results-container" style="margin-top:1em;"></div>
+</div>
 
-<div id="process-section" style="display:none;">
-    <label>Instructions:</label><br>
-    <textarea id="instructions" style="height:80px;"></textarea><br>
-    <label>Prompt (use column names in {braces}):</label><br>
-    <input type="text" id="prompt" style="width:100%;" placeholder="e.g. Summarize {name}"><br>
-    <label>Row index for single run:</label>
-    <input type="number" id="row-index" value="0" min="0"><br>
-    <button id="process-single-btn">Process Single Row</button>
-    <button id="process-btn">Process All Rows</button>
+<div id="step3" style="margin-top:2em;">
+    <h2>STEP 3: (placeholder)</h2>
 </div>
 
 <script src="{{ url_for('static', filename='js/main.js') }}"></script>


### PR DESCRIPTION
## Summary
- organize the interface into Step 1 (data load) and Step 2 (generate contacts)
- show GPT results in their own table instead of replacing the input data
- add placeholder Step 3 section
- update JavaScript to handle new tables

## Testing
- `python -m py_compile app.py routes.py processing.py`

------
https://chatgpt.com/codex/tasks/task_e_687e8e879e2c8333bfe30db9482b68b9