### PR TITLE
Simplify setup persistence

### DIFF
--- a/static/js/step1.js
+++ b/static/js/step1.js
@@ -3,14 +3,6 @@ function loadSavedSetup(){
     const savedInstructions = localStorage.getItem('saved_instructions') || '';
     const savedPrompt = localStorage.getItem('saved_prompt') || '';
 
-    $('#saved-tsv').val(savedTsv);
-    $('#saved-instructions').val(savedInstructions);
-    $('#saved-prompt').val(savedPrompt);
-
-    if(savedTsv || savedInstructions || savedPrompt){
-        $('#past-section').show();
-    }
-
     return {savedTsv, savedInstructions, savedPrompt};
 }
 
@@ -63,19 +55,6 @@ $('#save-setup-btn').on('click', function(){
     localStorage.setItem('saved_tsv', $('#tsv-input').val());
     localStorage.setItem('saved_instructions', $('#instructions').val());
     localStorage.setItem('saved_prompt', $('#prompt').val());
-    loadSavedSetup();
-});
-
-$('#load-setup-btn').on('click', function(){
-    $('#tsv-input').val($('#saved-tsv').val());
-    $('#instructions').val($('#saved-instructions').val());
-    $('#prompt').val($('#saved-prompt').val());
-});
-
-$('#saved-tsv, #saved-instructions, #saved-prompt').on('change', function(){
-    localStorage.setItem('saved_tsv', $('#saved-tsv').val());
-    localStorage.setItem('saved_instructions', $('#saved-instructions').val());
-    localStorage.setItem('saved_prompt', $('#saved-prompt').val());
 });
 
 function renderDataTable(data){

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,16 +22,6 @@
         <button type="button" id="save-setup-btn">Save Setup</button>
     </form>
 
-    <div id="past-section" style="display:none; margin-top:1em;">
-        <h3>Saved Setup</h3>
-        <label>TSV Input:</label><br>
-        <textarea id="saved-tsv"></textarea><br>
-        <label>Instructions:</label><br>
-        <textarea id="saved-instructions" style="height:80px;"></textarea><br>
-        <label>Prompt:</label><br>
-        <input type="text" id="saved-prompt" style="width:100%;"><br>
-        <button type="button" id="load-setup-btn">Load Saved Setup</button>
-    </div>
 
     <div id="table-container"></div>
 </div>


### PR DESCRIPTION
## Summary
- remove separate saved setup form
- store setup data in localStorage directly from main fields

## Testing
- `python -m py_compile app.py processing.py steps/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ee0da421c8333bc6c78b8176658fe