### PR TITLE
Add business name filtering and persist outputs

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -73,7 +73,20 @@ def parse_results_to_contacts(results):
     contacts = []
     for row in results:
         raw = row.get('result', '') if isinstance(row, dict) else str(row)
-        contacts.extend(parse_contacts(raw))
+        business_name = None
+        if isinstance(row, dict):
+            for key in row.keys():
+                lower = key.lower()
+                if lower == 'business name' or lower == 'business_name' or (
+                    'business' in lower and 'name' in lower):
+                    business_name = row[key]
+                    break
+            if business_name is None and 'name' in row:
+                business_name = row['name']
+        for contact in parse_contacts(raw):
+            if business_name is not None:
+                contact['business_name'] = business_name
+            contacts.append(contact)
     return contacts
 
 

--- a/processing.py
+++ b/processing.py
@@ -68,21 +68,21 @@ def parse_contacts(raw_result: str):
             return []
 
 
+def _extract_business_name(row: dict):
+    """Try to guess the business name column from the given row."""
+    for key, value in row.items():
+        lower = key.lower().replace('_', ' ')
+        if 'business' in lower and 'name' in lower:
+            return value
+    return row.get('name')
+
+
 def parse_results_to_contacts(results):
     """Parse the 'result' field from each row of step 2 output."""
     contacts = []
     for row in results:
         raw = row.get('result', '') if isinstance(row, dict) else str(row)
-        business_name = None
-        if isinstance(row, dict):
-            for key in row.keys():
-                lower = key.lower()
-                if lower == 'business name' or lower == 'business_name' or (
-                    'business' in lower and 'name' in lower):
-                    business_name = row[key]
-                    break
-            if business_name is None and 'name' in row:
-                business_name = row['name']
+        business_name = _extract_business_name(row) if isinstance(row, dict) else None
         for contact in parse_contacts(raw):
             if business_name is not None:
                 contact['business_name'] = business_name

--- a/static/js/step2.js
+++ b/static/js/step2.js
@@ -1,14 +1,28 @@
 var step2Results = [];
 
+function getBusinessNameKey(obj){
+    for(var key in obj){
+        var lower = key.toLowerCase();
+        if(lower === 'business name' || lower === 'business_name' ||
+           (lower.includes('business') && lower.includes('name'))){
+            return key;
+        }
+    }
+    if(obj.hasOwnProperty('name')) return 'name';
+    return Object.keys(obj)[0];
+}
+
 function renderResultsTable(data){
     if(!data.length){ $('#results-container').html('No results'); return; }
-    var html = '<table><thead><tr>';
-    Object.keys(data[0]).forEach(function(col){ html += '<th>'+col+'</th>'; });
-    html += '</tr></thead><tbody>';
+    var businessKey = getBusinessNameKey(data[0]);
+    var html = '<table><thead><tr>' +
+               '<th>'+businessKey+'</th><th>result</th>' +
+               '</tr></thead><tbody>';
     data.forEach(function(row){
-        html += '<tr>';
-        Object.values(row).forEach(function(val){ html += '<td>'+val+'</td>'; });
-        html += '</tr>';
+        html += '<tr>' +
+                 '<td>'+(row[businessKey] || '')+'</td>' +
+                 '<td>'+row.result+'</td>' +
+                 '</tr>';
     });
     html += '</tbody></table>';
     $('#results-container').html(html);
@@ -20,8 +34,8 @@ function addOrUpdateResultRow(rowData, index){
         renderResultsTable([rowData]);
         return;
     }
-    var keys = Object.keys(rowData);
-    var rowHtml = '<tr>' + keys.map(function(k){ return '<td>'+rowData[k]+'</td>'; }).join('') + '</tr>';
+    var businessKey = getBusinessNameKey(rowData);
+    var rowHtml = '<tr><td>'+(rowData[businessKey] || '')+'</td><td>'+rowData.result+'</td></tr>';
     var $rows = $table.find('tbody tr');
     if(index < $rows.length){
         $rows.eq(index).replaceWith(rowHtml);
@@ -62,4 +76,18 @@ $('#process-single-btn').on('click', function(){
         },
         error: function(xhr){ alert(xhr.responseText); }
     });
+});
+
+$(document).ready(function(){
+    var saved = localStorage.getItem('saved_results');
+    if(saved){
+        try {
+            step2Results = JSON.parse(saved);
+            renderResultsTable(step2Results);
+        } catch(e){ console.error(e); }
+    }
+});
+
+$('#save-setup-btn').on('click', function(){
+    localStorage.setItem('saved_results', JSON.stringify(step2Results));
 });

--- a/static/js/step3.js
+++ b/static/js/step3.js
@@ -12,12 +12,18 @@ $(document).ready(function(){
 
 function renderContactsTable(data){
     if(!data.length){ $('#contacts-container').html('No contacts'); return; }
+    var cols = Object.keys(data[0]);
+    cols.sort(function(a,b){
+        if(a === 'business_name') return -1;
+        if(b === 'business_name') return 1;
+        return 0;
+    });
     var html = '<table><thead><tr>';
-    Object.keys(data[0]).forEach(function(col){ html += '<th>'+col+'</th>'; });
+    cols.forEach(function(col){ html += '<th>'+col+'</th>'; });
     html += '</tr></thead><tbody>';
     data.forEach(function(row){
         html += '<tr>';
-        Object.values(row).forEach(function(val){ html += '<td>'+val+'</td>'; });
+        cols.forEach(function(k){ html += '<td>'+(row[k] || '')+'</td>'; });
         html += '</tr>';
     });
     html += '</tbody></table>';

--- a/static/js/step3.js
+++ b/static/js/step3.js
@@ -1,5 +1,15 @@
 var parsedContacts = [];
 
+$(document).ready(function(){
+    var saved = localStorage.getItem('saved_contacts');
+    if(saved){
+        try {
+            parsedContacts = JSON.parse(saved);
+            renderContactsTable(parsedContacts);
+        } catch(e){ console.error(e); }
+    }
+});
+
 function renderContactsTable(data){
     if(!data.length){ $('#contacts-container').html('No contacts'); return; }
     var html = '<table><thead><tr>';
@@ -30,4 +40,8 @@ $('#parse-btn').on('click', function(){
         },
         error: function(xhr){ alert(xhr.responseText); }
     });
+});
+
+$('#save-setup-btn').on('click', function(){
+    localStorage.setItem('saved_contacts', JSON.stringify(parsedContacts));
 });


### PR DESCRIPTION
## Summary
- filter Step2 output to display only business name and result
- persist Step2 results and Step3 contacts in localStorage
- include business name with parsed contacts

## Testing
- `python -m py_compile app.py processing.py steps/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ef90fb2a083338e97d3ef895cfc6d