### PR TITLE
Add step4 processing workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from flask import Flask
 from dotenv import load_dotenv
 import openai
 
-from steps import step1_bp, step2_bp, step3_bp
+from steps import step1_bp, step2_bp, step3_bp, step4_bp
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -16,6 +16,7 @@ def create_app():
     app.register_blueprint(step1_bp)
     app.register_blueprint(step2_bp)
     app.register_blueprint(step3_bp)
+    app.register_blueprint(step4_bp)
 
     return app
 

--- a/static/js/step4.js
+++ b/static/js/step4.js
@@ -1,0 +1,116 @@
+var step4Results = [];
+
+$(document).ready(function () {
+  var saved = localStorage.getItem("saved_step4_results");
+  if (saved) {
+    try {
+      step4Results = JSON.parse(saved);
+      renderStep4ResultsTable(step4Results);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+});
+
+function renderStep4ResultsTable(data) {
+  if (!data.length) {
+    $("#step4-results-container").html("No results");
+    return;
+  }
+  var cols = Object.keys(data[0]);
+  var html = "<table><thead><tr>";
+  cols.forEach(function (col) {
+    html += "<th>" + col + "</th>";
+  });
+  html += "</tr></thead><tbody>";
+  data.forEach(function (row) {
+    html += "<tr>";
+    cols.forEach(function (c) {
+      html += "<td>" + (row[c] || "") + "</td>";
+    });
+    html += "</tr>";
+  });
+  html += "</tbody></table>";
+  $("#step4-results-container").html(html);
+}
+
+function addOrUpdateStep4ResultRow(rowData, index) {
+  var $table = $("#step4-results-container table");
+  if (!$table.length) {
+    renderStep4ResultsTable([rowData]);
+    return;
+  }
+  var cols = Object.keys(rowData);
+  var rowHtml = "<tr>";
+  cols.forEach(function (c) {
+    rowHtml += "<td>" + (rowData[c] || "") + "</td>";
+  });
+  rowHtml += "</tr>";
+  var $rows = $table.find("tbody tr");
+  if (index < $rows.length) {
+    $rows.eq(index).replaceWith(rowHtml);
+  } else {
+    $table.find("tbody").append(rowHtml);
+  }
+}
+
+$("#process-step4-btn").on("click", function () {
+  if (!parsedContacts.length) {
+    alert("No parsed contacts to process");
+    return;
+  }
+  var prompt = $("#prompt-step4").val();
+  var instructions = $("#instructions-step4").val();
+  $.ajax({
+    url: "/step4/process",
+    method: "POST",
+    contentType: "application/json",
+    data: JSON.stringify({
+      prompt: prompt,
+      instructions: instructions,
+      contacts: parsedContacts,
+    }),
+    success: function (data) {
+      step4Results = data;
+      renderStep4ResultsTable(data);
+    },
+    error: function (xhr) {
+      alert(xhr.responseText);
+    },
+  });
+});
+
+$("#process-single-step4-btn").on("click", function () {
+  if (!parsedContacts.length) {
+    alert("No parsed contacts to process");
+    return;
+  }
+  var prompt = $("#prompt-step4").val();
+  var instructions = $("#instructions-step4").val();
+  var rowIndex = parseInt($("#row-index-step4").val()) || 0;
+  if (rowIndex < 0 || rowIndex >= parsedContacts.length) {
+    alert("Invalid row index");
+    return;
+  }
+  $.ajax({
+    url: "/step4/process_single",
+    method: "POST",
+    contentType: "application/json",
+    data: JSON.stringify({
+      prompt: prompt,
+      instructions: instructions,
+      contact: parsedContacts[rowIndex],
+    }),
+    success: function (data) {
+      step4Results[rowIndex] = data;
+      addOrUpdateStep4ResultRow(data, rowIndex);
+    },
+    error: function (xhr) {
+      alert(xhr.responseText);
+    },
+  });
+});
+
+$("#save-setup-btn").on("click", function () {
+  localStorage.setItem("saved_step4_results", JSON.stringify(step4Results));
+});

--- a/steps/__init__.py
+++ b/steps/__init__.py
@@ -3,9 +3,11 @@
 from .step1 import step1_bp
 from .step2 import step2_bp
 from .step3 import step3_bp
+from .step4 import step4_bp
 
 __all__ = [
     "step1_bp",
     "step2_bp",
     "step3_bp",
+    "step4_bp",
 ]

--- a/steps/step4.py
+++ b/steps/step4.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, jsonify, request
+import pandas as pd
+
+from processing import apply_prompt_to_dataframe, apply_prompt_to_row
+
+step4_bp = Blueprint("step4", __name__, url_prefix="/step4")
+
+
+@step4_bp.route("/process", methods=["POST"])
+def process():
+    """Apply a prompt to each contact row from Step 3."""
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    contacts = request.json.get("contacts", [])
+
+    df = pd.DataFrame(contacts)
+    results = apply_prompt_to_dataframe(df, instructions, prompt)
+    return jsonify(results)
+
+
+@step4_bp.route("/process_single", methods=["POST"])
+def process_single():
+    """Process a single contact row."""
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    contact = request.json.get("contact")
+
+    if contact is None:
+        return "No contact provided", 400
+
+    row = pd.Series(contact)
+    result = apply_prompt_to_row(row, instructions, prompt)
+    new_row = {**contact, "result": result}
+    return jsonify(new_row)

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,8 +47,24 @@
     <div id="contacts-container" style="margin-top:1em;"></div>
 </div>
 
+<div id="step4" style="margin-top:2em;">
+    <h2>STEP 4: Enrich Contacts</h2>
+    <div id="step4-process-section">
+        <label>Instructions:</label><br>
+        <textarea id="instructions-step4" style="height:80px;"></textarea><br>
+        <label>Prompt (use column names in {braces}):</label><br>
+        <input type="text" id="prompt-step4" style="width:100%;" placeholder="e.g. Enrich {business_name}"><br>
+        <label>Row index for single run:</label>
+        <input type="number" id="row-index-step4" value="0" min="0"><br>
+        <button id="process-single-step4-btn">Process Single Row</button>
+        <button id="process-step4-btn">Process All Rows</button>
+    </div>
+    <div id="step4-results-container" style="margin-top:1em;"></div>
+</div>
+
 <script src="{{ url_for('static', filename='js/step1.js') }}"></script>
 <script src="{{ url_for('static', filename='js/step2.js') }}"></script>
 <script src="{{ url_for('static', filename='js/step3.js') }}"></script>
+<script src="{{ url_for('static', filename='js/step4.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Step 4 backend routes for processing parsed contact data
- register Step 4 blueprint in the app
- update blueprint registration exports
- create frontend UI/JS for Step 4 processing
- include Step 4 section in main page

## Testing
- `python -m compileall -q steps/*.py app.py processing.py`

------
https://chatgpt.com/codex/tasks/task_e_687ff49bda80833397f3a382ed87f274