### PR TITLE
Add tool-based output for steps

### DIFF
--- a/steps/step2.py
+++ b/steps/step2.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 
 from . import data_store
 from processing import apply_prompt_to_dataframe, apply_prompt_to_row
+from tools import get_step2_tool
 
 step2_bp = Blueprint("step2", __name__)
 
@@ -11,7 +12,10 @@ def process():
     """Apply the prompt to the entire DataFrame."""
     prompt = request.json.get("prompt", "")
     instructions = request.json.get("instructions", "")
-    results = apply_prompt_to_dataframe(data_store.DATAFRAME, instructions, prompt)
+    tool = get_step2_tool()
+    results = apply_prompt_to_dataframe(
+        data_store.DATAFRAME, instructions, prompt, tools=[tool]
+    )
     return jsonify(results)
 
 
@@ -30,7 +34,8 @@ def process_single():
         return "Invalid row index", 400
 
     row = data_store.DATAFRAME.iloc[row_index]
-    result = apply_prompt_to_row(row, instructions, prompt)
+    tool = get_step2_tool()
+    result = apply_prompt_to_row(row, instructions, prompt, tools=[tool])
     new_row = row.to_dict()
     new_row["result"] = result
     return jsonify(new_row)

--- a/steps/step4.py
+++ b/steps/step4.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 import pandas as pd
 
 from processing import apply_prompt_to_dataframe, apply_prompt_to_row
+from tools import get_step4_tool
 
 step4_bp = Blueprint("step4", __name__, url_prefix="/step4")
 
@@ -14,7 +15,8 @@ def process():
     contacts = request.json.get("contacts", [])
 
     df = pd.DataFrame(contacts)
-    results = apply_prompt_to_dataframe(df, instructions, prompt)
+    tool = get_step4_tool()
+    results = apply_prompt_to_dataframe(df, instructions, prompt, tools=[tool])
     return jsonify(results)
 
 
@@ -29,6 +31,7 @@ def process_single():
         return "No contact provided", 400
 
     row = pd.Series(contact)
-    result = apply_prompt_to_row(row, instructions, prompt)
+    tool = get_step4_tool()
+    result = apply_prompt_to_row(row, instructions, prompt, tools=[tool])
     new_row = {**contact, "result": result}
     return jsonify(new_row)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Utility functions for OpenAI tools."""
+
+from .step2_tool import get_step2_tool
+from .step4_tool import get_step4_tool
+
+__all__ = ["get_step2_tool", "get_step4_tool"]

--- a/tools/step2_tool.py
+++ b/tools/step2_tool.py
@@ -1,0 +1,32 @@
+"""Tool definition for Step 2 ChatGPT calls."""
+
+
+def get_step2_tool() -> dict:
+    """Return the OpenAI tool definition for generating contacts."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "create_contacts",
+            "description": (
+                "Return a list of contacts with 'firstname', 'lastname', and 'role'."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "contacts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "firstname": {"type": "string"},
+                                "lastname": {"type": "string"},
+                                "role": {"type": "string"},
+                            },
+                            "required": ["firstname", "lastname", "role"],
+                        },
+                    }
+                },
+                "required": ["contacts"],
+            },
+        },
+    }

--- a/tools/step4_tool.py
+++ b/tools/step4_tool.py
@@ -1,0 +1,17 @@
+"""Tool definition for Step 4 ChatGPT calls."""
+
+
+def get_step4_tool() -> dict:
+    """Return the OpenAI tool definition for enriching contacts with an email."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "create_email",
+            "description": "Return a valid email address as a simple string.",
+            "parameters": {
+                "type": "object",
+                "properties": {"email": {"type": "string", "format": "email"}},
+                "required": ["email"],
+            },
+        },
+    }


### PR DESCRIPTION
## Summary
- add tool definitions for generating contacts and emails
- pass tools to the OpenAI client for step 2 and step 4
- parse new JSON structures from tool calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68801651a0dc8333ad1993338d69017c