### PR TITLE
Add multi-phase pages with navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from flask import Flask
 from dotenv import load_dotenv
 import openai
 
-from steps import step1_bp, step2_bp, step3_bp
+from steps import pages_bp, step1_bp, step2_bp, step3_bp
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -13,6 +13,7 @@ def create_app():
     app = Flask(__name__)
 
     # Register blueprints for each step of the UI
+    app.register_blueprint(pages_bp)
     app.register_blueprint(step1_bp)
     app.register_blueprint(step2_bp)
     app.register_blueprint(step3_bp)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
       - .env
     environment:
       FLASK_APP: app.py
+      FLASK_ENVIRONMENT: development
+      FLASK_DEBUG: 1
     volumes:
       - .:/app
     depends_on:

--- a/processing.py
+++ b/processing.py
@@ -119,6 +119,28 @@ def parse_results_to_contacts(results):
     return contacts
 
 
+def parse_json_response(raw_result: str):
+    """Parse a JSON array or object from an OpenAI response."""
+    try:
+        return json.loads(raw_result)
+    except json.JSONDecodeError:
+        cleaned = _strip_json_codeblock(raw_result)
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError:
+            return []
+
+
+def fetch_subregions(location: str, instructions: str):
+    """Return list of subregions and populations for a location."""
+    message = (
+        f"For the location '{location}', list its immediate subregions with their population. "
+        "Respond in JSON array of objects with 'region' and 'population' fields."
+    )
+    raw = _call_openai(instructions, message)
+    return parse_json_response(raw)
+
+
 def apply_prompt_to_dataframe(df: pd.DataFrame, instructions: str, prompt: str):
     """Apply the prompt to each row of the dataframe and return results."""
     processed = []

--- a/static/js/phase1.js
+++ b/static/js/phase1.js
@@ -1,0 +1,34 @@
+$("#process-btn").on("click", function () {
+  var location = $("#location-input").val();
+  var instructions = $("#instructions").val();
+  $.ajax({
+    url: "/phase1/process",
+    method: "POST",
+    contentType: "application/json",
+    data: JSON.stringify({ location: location, instructions: instructions }),
+    success: function (data) {
+      renderTable(data);
+    },
+    error: function (xhr) {
+      alert(xhr.responseText);
+    },
+  });
+});
+
+function renderTable(data) {
+  if (!data.length) {
+    $("#results-container").html("No results");
+    return;
+  }
+  var html = "<table><thead><tr><th>region</th><th>population</th></tr></thead><tbody>";
+  data.forEach(function (row) {
+    html +=
+      "<tr><td>" +
+      (row.region || "") +
+      "</td><td>" +
+      (row.population || "") +
+      "</td></tr>";
+  });
+  html += "</tbody></table>";
+  $("#results-container").html(html);
+}

--- a/steps/__init__.py
+++ b/steps/__init__.py
@@ -3,9 +3,11 @@
 from .step1 import step1_bp
 from .step2 import step2_bp
 from .step3 import step3_bp
+from .pages import pages_bp
 
 __all__ = [
     "step1_bp",
     "step2_bp",
     "step3_bp",
+    "pages_bp",
 ]

--- a/steps/pages.py
+++ b/steps/pages.py
@@ -1,0 +1,43 @@
+"""Blueprint for application pages and Phase 1 processing."""
+
+from flask import Blueprint, jsonify, render_template, request
+
+from processing import fetch_subregions
+
+pages_bp = Blueprint("pages", __name__)
+
+
+@pages_bp.route("/")
+def home():
+    """Render home page with links to all phases."""
+    return render_template("index.html")
+
+
+@pages_bp.route("/phase1")
+def phase1_page():
+    """Render Phase 1 page for parsing locations."""
+    return render_template("phase1.html")
+
+
+@pages_bp.route("/phase2")
+def phase2_page():
+    """Render placeholder Phase 2 page."""
+    return render_template("phase2.html")
+
+
+@pages_bp.route("/phase3")
+def phase3_page():
+    """Render Phase 3 page with existing functionality."""
+    return render_template("phase3.html")
+
+
+@pages_bp.route("/phase1/process", methods=["POST"])
+def process_location():
+    """Process a single location and return subregions with populations."""
+    data = request.json or {}
+    location = data.get("location", "").strip()
+    instructions = data.get("instructions", "")
+    if not location:
+        return "No location provided", 400
+    regions = fetch_subregions(location, instructions)
+    return jsonify(regions)

--- a/steps/pages.py
+++ b/steps/pages.py
@@ -12,25 +12,6 @@ def home():
     """Render home page with links to all phases."""
     return render_template("index.html")
 
-
-@pages_bp.route("/phase1")
-def phase1_page():
-    """Render Phase 1 page for parsing locations."""
-    return render_template("phase1.html")
-
-
-@pages_bp.route("/phase2")
-def phase2_page():
-    """Render placeholder Phase 2 page."""
-    return render_template("phase2.html")
-
-
-@pages_bp.route("/phase3")
-def phase3_page():
-    """Render Phase 3 page with existing functionality."""
-    return render_template("phase3.html")
-
-
 @pages_bp.route("/phase1/process", methods=["POST"])
 def process_location():
     """Process a single location and return subregions with populations."""

--- a/steps/step1.py
+++ b/steps/step1.py
@@ -1,16 +1,10 @@
 import io
 import pandas as pd
-from flask import Blueprint, render_template, request
+from flask import Blueprint, request
 
 from . import data_store
 
 step1_bp = Blueprint("step1", __name__)
-
-
-@step1_bp.route("/")
-def index():
-    """Render the main page."""
-    return render_template("index.html")
 
 
 @step1_bp.route("/upload", methods=["POST"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,16 +10,16 @@
 </head>
 <body>
 <nav>
-    <a href="{{ url_for('pages.home') }}">Home</a> |
-    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
-    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
-    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
+    <a href="/templates/index.html">Home</a> |
+    <a href="/templates/phase1.html">PHASE 1 - parse locations</a> |
+    <a href="/templates/phase2.html">PHASE 2 - generate businesses</a> |
+    <a href="/templates/phase3.html">PHASE 3 - generate contacts</a>
 </nav>
 <h1>SFA Lead Generator</h1>
 <ul>
-    <li><a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a></li>
-    <li><a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a></li>
-    <li><a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a></li>
+    <li><a href="/templates/phase1.html">PHASE 1 - parse locations</a></li>
+    <li><a href="/templates/phase2.html">PHASE 2 - generate businesses</a></li>
+    <li><a href="/templates/phase3.html">PHASE 3 - generate contacts</a></li>
 </ul>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,16 +10,16 @@
 </head>
 <body>
 <nav>
-    <a href="/">Home</a> |
-    <a href="/phase1">PHASE 1 - parse locations</a> |
-    <a href="/phase2">PHASE 2 - generate businesses</a> |
-    <a href="/phase3">PHASE 3 - generate contacts</a>
+    <a href="{{ url_for('pages.home') }}">Home</a> |
+    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
+    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
+    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
 </nav>
 <h1>SFA Lead Generator</h1>
 <ul>
-    <li><a href="/phase1">PHASE 1 - parse locations</a></li>
-    <li><a href="/phase2">PHASE 2 - generate businesses</a></li>
-    <li><a href="/phase3">PHASE 3 - generate contacts</a></li>
+    <li><a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a></li>
+    <li><a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a></li>
+    <li><a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a></li>
 </ul>
 </body>
 </html>

--- a/templates/phase1.html
+++ b/templates/phase1.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PHASE 1 - parse locations</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <style>
+        table { border-collapse: collapse; margin-top: 1em; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+        textarea { width: 100%; height: 80px; }
+        nav a { margin-right: 1em; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">Home</a> |
+    <a href="/phase1">PHASE 1 - parse locations</a> |
+    <a href="/phase2">PHASE 2 - generate businesses</a> |
+    <a href="/phase3">PHASE 3 - generate contacts</a>
+</nav>
+<h1>PHASE 1 - parse locations</h1>
+<div id="step1">
+    <h2>STEP 1: Location Input</h2>
+    <label>Location:</label><br>
+    <input type="text" id="location-input" style="width:100%;"/><br>
+    <label>Instructions:</label><br>
+    <textarea id="instructions"></textarea><br>
+    <button id="process-btn">Process One Depth</button>
+    <div id="results-container"></div>
+</div>
+<script src="{{ url_for('static', filename='js/phase1.js') }}"></script>
+</body>
+</html>

--- a/templates/phase1.html
+++ b/templates/phase1.html
@@ -13,10 +13,10 @@
 </head>
 <body>
 <nav>
-    <a href="{{ url_for('pages.home') }}">Home</a> |
-    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
-    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
-    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
+    <a href="/templates/index.html">Home</a> |
+    <a href="/templates/phase1.html">PHASE 1 - parse locations</a> |
+    <a href="/templates/phase2.html">PHASE 2 - generate businesses</a> |
+    <a href="/templates/phase3.html">PHASE 3 - generate contacts</a>
 </nav>
 <h1>PHASE 1 - parse locations</h1>
 <div id="step1">
@@ -28,6 +28,6 @@
     <button id="process-btn">Process One Depth</button>
     <div id="results-container"></div>
 </div>
-<script src="{{ url_for('static', filename='js/phase1.js') }}"></script>
+<script src="../static/js/phase1.js"></script>
 </body>
 </html>

--- a/templates/phase1.html
+++ b/templates/phase1.html
@@ -13,10 +13,10 @@
 </head>
 <body>
 <nav>
-    <a href="/">Home</a> |
-    <a href="/phase1">PHASE 1 - parse locations</a> |
-    <a href="/phase2">PHASE 2 - generate businesses</a> |
-    <a href="/phase3">PHASE 3 - generate contacts</a>
+    <a href="{{ url_for('pages.home') }}">Home</a> |
+    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
+    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
+    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
 </nav>
 <h1>PHASE 1 - parse locations</h1>
 <div id="step1">

--- a/templates/phase2.html
+++ b/templates/phase2.html
@@ -10,10 +10,10 @@
 </head>
 <body>
 <nav>
-    <a href="/">Home</a> |
-    <a href="/phase1">PHASE 1 - parse locations</a> |
-    <a href="/phase2">PHASE 2 - generate businesses</a> |
-    <a href="/phase3">PHASE 3 - generate contacts</a>
+    <a href="{{ url_for('pages.home') }}">Home</a> |
+    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
+    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
+    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
 </nav>
 <h1>PHASE 2 - generate businesses</h1>
 <p>Content coming soon.</p>

--- a/templates/phase2.html
+++ b/templates/phase2.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>SFA Lead Generator</title>
+    <title>PHASE 2 - generate businesses</title>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <style>
         nav a { margin-right: 1em; }
@@ -15,11 +15,7 @@
     <a href="/phase2">PHASE 2 - generate businesses</a> |
     <a href="/phase3">PHASE 3 - generate contacts</a>
 </nav>
-<h1>SFA Lead Generator</h1>
-<ul>
-    <li><a href="/phase1">PHASE 1 - parse locations</a></li>
-    <li><a href="/phase2">PHASE 2 - generate businesses</a></li>
-    <li><a href="/phase3">PHASE 3 - generate contacts</a></li>
-</ul>
+<h1>PHASE 2 - generate businesses</h1>
+<p>Content coming soon.</p>
 </body>
 </html>

--- a/templates/phase2.html
+++ b/templates/phase2.html
@@ -10,10 +10,10 @@
 </head>
 <body>
 <nav>
-    <a href="{{ url_for('pages.home') }}">Home</a> |
-    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
-    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
-    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
+    <a href="/templates/index.html">Home</a> |
+    <a href="/templates/phase1.html">PHASE 1 - parse locations</a> |
+    <a href="/templates/phase2.html">PHASE 2 - generate businesses</a> |
+    <a href="/templates/phase3.html">PHASE 3 - generate contacts</a>
 </nav>
 <h1>PHASE 2 - generate businesses</h1>
 <p>Content coming soon.</p>

--- a/templates/phase3.html
+++ b/templates/phase3.html
@@ -13,10 +13,10 @@
 </head>
 <body>
 <nav>
-    <a href="{{ url_for('pages.home') }}">Home</a> |
-    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
-    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
-    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
+    <a href="/templates/index.html">Home</a> |
+    <a href="/templates/phase1.html">PHASE 1 - parse locations</a> |
+    <a href="/templates/phase2.html">PHASE 2 - generate businesses</a> |
+    <a href="/templates/phase3.html">PHASE 3 - generate contacts</a>
 </nav>
 <h1>PHASE 3 - generate contacts</h1>
 
@@ -54,8 +54,8 @@
     <div id="contacts-container" style="margin-top:1em;"></div>
 </div>
 
-<script src="{{ url_for('static', filename='js/step1.js') }}"></script>
-<script src="{{ url_for('static', filename='js/step2.js') }}"></script>
-<script src="{{ url_for('static', filename='js/step3.js') }}"></script>
+<script src="../static/js/step1.js"></script>
+<script src="../static/js/step2.js"></script>
+<script src="../static/js/step3.js"></script>
 </body>
 </html>

--- a/templates/phase3.html
+++ b/templates/phase3.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PHASE 3 - generate contacts</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <style>
+        table { border-collapse: collapse; margin-top: 1em; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+        textarea { width: 100%; height: 150px; }
+        nav a { margin-right: 1em; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">Home</a> |
+    <a href="/phase1">PHASE 1 - parse locations</a> |
+    <a href="/phase2">PHASE 2 - generate businesses</a> |
+    <a href="/phase3">PHASE 3 - generate contacts</a>
+</nav>
+<h1>PHASE 3 - generate contacts</h1>
+
+<div id="step1">
+    <h2>STEP 1: Initial Data Load</h2>
+    <form id="upload-form" method="post" enctype="multipart/form-data">
+        <label>Paste TSV Data:</label><br>
+        <textarea name="tsv_text" id="tsv-input"></textarea><br>
+        <button type="submit">Load Data</button>
+        <button type="button" id="save-setup-btn">Save Setup</button>
+    </form>
+
+
+    <div id="table-container"></div>
+</div>
+
+<div id="step2" style="margin-top:2em;">
+    <h2>STEP 2: Generate Contacts</h2>
+    <div id="process-section">
+        <label>Instructions:</label><br>
+        <textarea id="instructions" style="height:80px;"></textarea><br>
+        <label>Prompt (use column names in {braces}):</label><br>
+        <input type="text" id="prompt" style="width:100%;" placeholder="e.g. Summarize {name}"><br>
+        <label>Row index for single run:</label>
+        <input type="number" id="row-index" value="0" min="0"><br>
+        <button id="process-single-btn">Process Single Row</button>
+        <button id="process-btn">Process All Rows</button>
+    </div>
+    <div id="results-container" style="margin-top:1em;"></div>
+</div>
+
+<div id="step3" style="margin-top:2em;">
+    <h2>STEP 3: Parse Contacts</h2>
+    <button id="parse-btn">Parse Step 2 Results</button>
+    <div id="contacts-container" style="margin-top:1em;"></div>
+</div>
+
+<script src="{{ url_for('static', filename='js/step1.js') }}"></script>
+<script src="{{ url_for('static', filename='js/step2.js') }}"></script>
+<script src="{{ url_for('static', filename='js/step3.js') }}"></script>
+</body>
+</html>

--- a/templates/phase3.html
+++ b/templates/phase3.html
@@ -13,10 +13,10 @@
 </head>
 <body>
 <nav>
-    <a href="/">Home</a> |
-    <a href="/phase1">PHASE 1 - parse locations</a> |
-    <a href="/phase2">PHASE 2 - generate businesses</a> |
-    <a href="/phase3">PHASE 3 - generate contacts</a>
+    <a href="{{ url_for('pages.home') }}">Home</a> |
+    <a href="{{ url_for('pages.phase1_page') }}">PHASE 1 - parse locations</a> |
+    <a href="{{ url_for('pages.phase2_page') }}">PHASE 2 - generate businesses</a> |
+    <a href="{{ url_for('pages.phase3_page') }}">PHASE 3 - generate contacts</a>
 </nav>
 <h1>PHASE 3 - generate contacts</h1>
 


### PR DESCRIPTION
## Summary
- Introduce a landing page and navigation across the app's phases
- Implement Phase 1 page for parsing locations via OpenAI and display results in a table
- Stub Phase 2 page and move existing workflow to Phase 3

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e19eca85c8333963ea9adffe1b56c