### PR TITLE
Add parse_locations page scaffolding

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from dotenv import load_dotenv
 import openai
 
 from backend.generate_contacts import step1_bp, step2_bp, step3_bp
+from backend.parse_locations import parse_locations_bp
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -16,6 +17,7 @@ def create_app():
     app.register_blueprint(step1_bp)
     app.register_blueprint(step2_bp)
     app.register_blueprint(step3_bp)
+    app.register_blueprint(parse_locations_bp)
 
     return app
 

--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, render_template
+
+parse_locations_bp = Blueprint("parse_locations", __name__)
+
+
+@parse_locations_bp.route("/parse_locations")
+def parse_locations():
+    """Render the parse locations page."""
+    return render_template("parse_locations.html")

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -7,5 +7,6 @@
 <body>
 <h1>SFA Lead Generator</h1>
 <p><a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a></p>
+<p><a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a></p>
 </body>
 </html>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Parse Locations</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+</head>
+<body>
+<h1>Parse Locations</h1>
+<form id="parse-locations-form">
+    <label for="population-stop-depth">Population Stop Depth:</label><br>
+    <input type="number" id="population-stop-depth" name="population_stop_depth"><br>
+
+    <label for="location">Location:</label><br>
+    <input type="text" id="location" name="location"><br>
+
+    <label for="gpt-prompt">GPT Prompt:</label><br>
+    <textarea id="gpt-prompt" name="gpt_prompt" style="width:100%; height:80px;"></textarea><br>
+
+    <button type="submit">Submit</button>
+</form>
+
+<script src="{{ url_for('static', filename='parse_locations/parse_locations.js') }}"></script>
+</body>
+</html>

--- a/frontend/js/parse_locations/parse_locations.js
+++ b/frontend/js/parse_locations/parse_locations.js
@@ -1,0 +1,1 @@
+console.log('parse_locations.js loaded');


### PR DESCRIPTION
## Summary
- add parse_locations blueprint and page with fields for population stop depth, location, and GPT prompt
- expose Parse Locations link on home page and register blueprint in app
- include placeholder frontend JS for parse locations

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890152f98cc83339bb51bfd32db631f