### PR TITLE
Add client-side table display for parse locations inputs

### DIFF
--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -9,7 +9,7 @@
 <h1>Parse Locations</h1>
 <form id="parse-locations-form">
     <label for="population-stop-depth">Population Stop Depth:</label><br>
-    <input type="number" id="population-stop-depth" name="population_stop_depth"><br>
+    <input type="number" id="population-stop-depth" name="population_stop_depth" value="100000" step="25000"><br>
 
     <label for="location">Location:</label><br>
     <input type="text" id="location" name="location"><br>
@@ -19,6 +19,8 @@
 
     <button type="submit">Submit</button>
 </form>
+
+<div id="results-container"></div>
 
 <script src="{{ url_for('static', filename='parse_locations/parse_locations.js') }}"></script>
 </body>

--- a/frontend/js/parse_locations/parse_locations.js
+++ b/frontend/js/parse_locations/parse_locations.js
@@ -1,1 +1,29 @@
 console.log('parse_locations.js loaded');
+
+$(document).ready(function () {
+    $('#parse-locations-form').on('submit', function (event) {
+        event.preventDefault();
+
+        const populationStopDepth = $('#population-stop-depth').val();
+        const location = $('#location').val();
+        const gptPrompt = $('#gpt-prompt').val();
+
+        let table = $('#results-table');
+        if (table.length === 0) {
+            table = $('<table id="results-table" border="1"></table>');
+            const header = $('<tr></tr>');
+            header.append('<th>Population Stop Depth</th>');
+            header.append('<th>Location</th>');
+            header.append('<th>GPT Prompt</th>');
+            table.append(header);
+            $('#results-container').append(table);
+        }
+
+        const row = $('<tr></tr>');
+        row.append($('<td></td>').text(populationStopDepth));
+        row.append($('<td></td>').text(location));
+        row.append($('<td></td>').text(gptPrompt));
+        table.append(row);
+    });
+});
+


### PR DESCRIPTION
## Summary
- Default population stop depth to 100,000 with 25,000 step increments
- Show submitted parse location inputs in a results table below the form

## Testing
- `python -m py_compile app.py backend/__init__.py backend/generate_contacts/__init__.py backend/generate_contacts/data_store.py backend/generate_contacts/processing.py backend/generate_contacts/step1.py backend/generate_contacts/step2.py backend/generate_contacts/step3.py backend/parse_locations/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6890189bf8948333aaff99ba030cb763