### PR TITLE
Use location field as GPT instructions in parse locations

### DIFF
--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -13,7 +13,9 @@ def parse_locations():
 
 @parse_locations_bp.route("/parse_locations/run_instructions", methods=["POST"])
 def run_instructions():
-    """Run the provided GPT instructions through OpenAI and return the result."""
-    instructions = (request.json or {}).get("instructions", "")
-    result = call_openai("", instructions, model="gpt-3.5-turbo")
+    """Run the provided prompt and GPT instructions through OpenAI and return the result."""
+    payload = request.json or {}
+    instructions = payload.get("instructions", "")
+    prompt = payload.get("prompt", "")
+    result = call_openai(instructions, prompt, model="gpt-3.5-turbo")
     return jsonify({"result": result})

--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -11,9 +11,9 @@ def parse_locations():
     return render_template("parse_locations.html")
 
 
-@parse_locations_bp.route("/parse_locations/run_prompt", methods=["POST"])
-def run_prompt():
-    """Run the provided prompt through OpenAI and return the result."""
-    prompt = (request.json or {}).get("prompt", "")
-    result = call_openai("", prompt, model="gpt-3.5-turbo")
+@parse_locations_bp.route("/parse_locations/run_instructions", methods=["POST"])
+def run_instructions():
+    """Run the provided GPT instructions through OpenAI and return the result."""
+    instructions = (request.json or {}).get("instructions", "")
+    result = call_openai("", instructions, model="gpt-3.5-turbo")
     return jsonify({"result": result})

--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -17,5 +17,6 @@ def run_instructions():
     payload = request.json or {}
     instructions = payload.get("instructions", "")
     prompt = payload.get("prompt", "")
-    result = call_openai(instructions, prompt, model="gpt-3.5-turbo")
+    temperature = payload.get("temperature", 0.5)
+    result = call_openai(instructions, prompt, model="gpt-3.5-turbo", temperature=temperature)
     return jsonify({"result": result})

--- a/backend/utilities/openai_helpers.py
+++ b/backend/utilities/openai_helpers.py
@@ -6,7 +6,12 @@ from openai import OpenAI
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
-def call_openai(instructions: str, message: str, model: str = "gpt-4o-search-preview") -> str:
+def call_openai(
+    instructions: str,
+    message: str,
+    model: str = "gpt-4o-search-preview",
+    temperature: float = 0.5,
+) -> str:
     """Return completion for the given message using the specified model or placeholder text."""
     if not client.api_key:
         return f"[placeholder] {message}"
@@ -14,6 +19,7 @@ def call_openai(instructions: str, message: str, model: str = "gpt-4o-search-pre
     print("\n[OpenAI Request]")
     print("System Instructions:", instructions)
     print("User Message:", message)
+    print("Temperature:", temperature)
 
     try:
         messages = []
@@ -24,6 +30,7 @@ def call_openai(instructions: str, message: str, model: str = "gpt-4o-search-pre
         extra_args = {}
         if "search" in model:
             extra_args["web_search_options"] = {}
+        extra_args["temperature"] = temperature
 
         response = client.chat.completions.create(
             model=model,

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -21,6 +21,9 @@
         <label for="gpt-instructions">GPT Instructions:</label><br>
         <textarea id="gpt-instructions" name="gpt_instructions" rows="4" cols="50"></textarea><br>
 
+        <label for="temperature">Temperature:</label><br>
+        <input type="number" id="temperature" name="temperature" min="0" max="2" step="0.1" value="0.5"><br>
+
         <button type="submit">Submit</button>
     </form>
 

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -16,9 +16,7 @@
 
         <label for="location">Location:</label><br>
         <input type="text" id="location" name="location"><br>
-
-        <label for="gpt-prompt">GPT Prompt:</label><br>
-        <textarea id="gpt-prompt" name="gpt_prompt" style="width:100%; height:80px;"></textarea><br>
+        <small>This data is passed into the GPT instructions.</small><br>
 
         <button type="submit">Submit</button>
     </form>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -16,7 +16,10 @@
 
         <label for="location">Location:</label><br>
         <input type="text" id="location" name="location"><br>
-        <small>This data is passed into the GPT instructions.</small><br>
+        <small>This value is sent as the GPT prompt.</small><br><br>
+
+        <label for="gpt-instructions">GPT Instructions:</label><br>
+        <textarea id="gpt-instructions" name="gpt_instructions" rows="4" cols="50"></textarea><br>
 
         <button type="submit">Submit</button>
     </form>

--- a/frontend/js/parse_locations/step1.js
+++ b/frontend/js/parse_locations/step1.js
@@ -6,13 +6,13 @@ $(document).ready(function () {
 
         const populationStopDepth = $('#population-stop-depth').val();
         const location = $('#location').val();
-        const gptPrompt = $('#gpt-prompt').val();
+        const gptInstructions = location;
 
         $.ajax({
-            url: '/parse_locations/run_prompt',
+            url: '/parse_locations/run_instructions',
             method: 'POST',
             contentType: 'application/json',
-            data: JSON.stringify({ prompt: gptPrompt }),
+            data: JSON.stringify({ instructions: gptInstructions }),
             success: function (data) {
                 const result = data.result;
 
@@ -22,7 +22,7 @@ $(document).ready(function () {
                     const header = $('<tr></tr>');
                     header.append('<th>Population Stop Depth</th>');
                     header.append('<th>Location</th>');
-                    header.append('<th>GPT Prompt</th>');
+                    header.append('<th>GPT Instructions</th>');
                     header.append('<th>Result</th>');
                     table.append(header);
                     $('#results-container').append(table);
@@ -31,7 +31,7 @@ $(document).ready(function () {
                 const row = $('<tr></tr>');
                 row.append($('<td></td>').text(populationStopDepth));
                 row.append($('<td></td>').text(location));
-                row.append($('<td></td>').text(gptPrompt));
+                row.append($('<td></td>').text(gptInstructions));
                 row.append($('<td></td>').text(result));
                 table.append(row);
             },

--- a/frontend/js/parse_locations/step1.js
+++ b/frontend/js/parse_locations/step1.js
@@ -6,13 +6,16 @@ $(document).ready(function () {
 
         const populationStopDepth = $('#population-stop-depth').val();
         const location = $('#location').val();
-        const gptInstructions = location;
+        const gptInstructions = $('#gpt-instructions').val();
 
         $.ajax({
             url: '/parse_locations/run_instructions',
             method: 'POST',
             contentType: 'application/json',
-            data: JSON.stringify({ instructions: gptInstructions }),
+            data: JSON.stringify({
+                instructions: gptInstructions,
+                prompt: location,
+            }),
             success: function (data) {
                 const result = data.result;
 

--- a/frontend/js/parse_locations/step1.js
+++ b/frontend/js/parse_locations/step1.js
@@ -7,6 +7,7 @@ $(document).ready(function () {
         const populationStopDepth = $('#population-stop-depth').val();
         const location = $('#location').val();
         const gptInstructions = $('#gpt-instructions').val();
+        const temperature = $('#temperature').val();
 
         $.ajax({
             url: '/parse_locations/run_instructions',
@@ -15,6 +16,7 @@ $(document).ready(function () {
             data: JSON.stringify({
                 instructions: gptInstructions,
                 prompt: location,
+                temperature: parseFloat(temperature),
             }),
             success: function (data) {
                 const result = data.result;
@@ -26,6 +28,7 @@ $(document).ready(function () {
                     header.append('<th>Population Stop Depth</th>');
                     header.append('<th>Location</th>');
                     header.append('<th>GPT Instructions</th>');
+                    header.append('<th>Temperature</th>');
                     header.append('<th>Result</th>');
                     table.append(header);
                     $('#results-container').append(table);
@@ -35,6 +38,7 @@ $(document).ready(function () {
                 row.append($('<td></td>').text(populationStopDepth));
                 row.append($('<td></td>').text(location));
                 row.append($('<td></td>').text(gptInstructions));
+                row.append($('<td></td>').text(temperature));
                 row.append($('<td></td>').text(result));
                 table.append(row);
             },

--- a/frontend/js/parse_locations/step1.js
+++ b/frontend/js/parse_locations/step1.js
@@ -27,7 +27,6 @@ $(document).ready(function () {
                     const header = $('<tr></tr>');
                     header.append('<th>Population Stop Depth</th>');
                     header.append('<th>Location</th>');
-                    header.append('<th>GPT Instructions</th>');
                     header.append('<th>Temperature</th>');
                     header.append('<th>Result</th>');
                     table.append(header);
@@ -37,7 +36,6 @@ $(document).ready(function () {
                 const row = $('<tr></tr>');
                 row.append($('<td></td>').text(populationStopDepth));
                 row.append($('<td></td>').text(location));
-                row.append($('<td></td>').text(gptInstructions));
                 row.append($('<td></td>').text(temperature));
                 row.append($('<td></td>').text(result));
                 table.append(row);


### PR DESCRIPTION
## Summary
- Replace separate GPT prompt field with location-based GPT instructions
- Post instructions to new `/parse_locations/run_instructions` API and adjust results table

## Testing
- `python -m py_compile backend/parse_locations/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_689023da7cf08333a6d1dcf950fa112e