### PR TITLE
Add step 2 processing to parse locations

### DIFF
--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -20,3 +20,32 @@ def run_instructions():
     temperature = payload.get("temperature", 0.5)
     result = call_openai(instructions, prompt, model="gpt-3.5-turbo", temperature=temperature)
     return jsonify({"result": result})
+
+
+@parse_locations_bp.route("/parse_locations/process_all", methods=["POST"])
+def process_all():
+    """Process all rows from step 1 using the provided GPT instructions."""
+    payload = request.json or {}
+    instructions = payload.get("instructions", "")
+    test_loop_depth = payload.get("test_loop_depth", 1)
+    data = payload.get("data", [])
+
+    results = []
+    for entry in data:
+        location = entry.get("location", "")
+        population = entry.get("result", "")
+        population_stop_depth = entry.get("population_stop_depth", "")
+        prompt = (
+            f"Location: {location}\n"
+            f"Population: {population}\n"
+            f"Population Stop Depth: {population_stop_depth}\n"
+            f"Test Loop Depth: {test_loop_depth}"
+        )
+        gpt_result = call_openai(instructions, prompt, model="gpt-3.5-turbo")
+        results.append({
+            "location": location,
+            "population": population,
+            "result": gpt_result,
+        })
+
+    return jsonify({"results": results})

--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -22,30 +22,76 @@ def run_instructions():
     return jsonify({"result": result})
 
 
-@parse_locations_bp.route("/parse_locations/process_all", methods=["POST"])
-def process_all():
-    """Process all rows from step 1 using the provided GPT instructions."""
+@parse_locations_bp.route("/parse_locations/process_single", methods=["POST"])
+def process_single():
+    """Process rows up to the provided test loop depth."""
     payload = request.json or {}
     instructions = payload.get("instructions", "")
-    test_loop_depth = payload.get("test_loop_depth", 1)
+    test_loop_depth = int(payload.get("test_loop_depth", 1))
     data = payload.get("data", [])
 
     results = []
     for entry in data:
         location = entry.get("location", "")
-        population = entry.get("result", "")
-        population_stop_depth = entry.get("population_stop_depth", "")
-        prompt = (
-            f"Location: {location}\n"
-            f"Population: {population}\n"
-            f"Population Stop Depth: {population_stop_depth}\n"
-            f"Test Loop Depth: {test_loop_depth}"
-        )
-        gpt_result = call_openai(instructions, prompt, model="gpt-3.5-turbo")
+        population = int(entry.get("result", 0))
+        population_stop_depth = int(entry.get("population_stop_depth", 0))
+
+        current_population = population
+        loop_depth = 1
+        while loop_depth <= test_loop_depth:
+            prompt = (
+                f"Location: {location}\n"
+                f"Population: {current_population}\n"
+                f"Population Stop Depth: {population_stop_depth}\n"
+                f"Test Loop Depth: {loop_depth}"
+            )
+            gpt_result = call_openai(instructions, prompt, model="gpt-3.5-turbo")
+            try:
+                current_population = int(gpt_result)
+            except (ValueError, TypeError):
+                break
+            loop_depth += 1
+
         results.append({
             "location": location,
-            "population": population,
-            "result": gpt_result,
+            "population": current_population,
+        })
+
+    return jsonify({"results": results})
+
+
+@parse_locations_bp.route("/parse_locations/process_all", methods=["POST"])
+def process_all():
+    """Process rows until population falls below the stop depth or max depth reached."""
+    payload = request.json or {}
+    instructions = payload.get("instructions", "")
+    data = payload.get("data", [])
+
+    results = []
+    for entry in data:
+        location = entry.get("location", "")
+        population = int(entry.get("result", 0))
+        population_stop_depth = int(entry.get("population_stop_depth", 0))
+
+        current_population = population
+        loop_depth = 1
+        while loop_depth <= 5 and current_population > population_stop_depth:
+            prompt = (
+                f"Location: {location}\n"
+                f"Population: {current_population}\n"
+                f"Population Stop Depth: {population_stop_depth}\n"
+                f"Test Loop Depth: {loop_depth}"
+            )
+            gpt_result = call_openai(instructions, prompt, model="gpt-3.5-turbo")
+            try:
+                current_population = int(gpt_result)
+            except (ValueError, TypeError):
+                break
+            loop_depth += 1
+
+        results.append({
+            "location": location,
+            "population": current_population,
         })
 
     return jsonify({"results": results})

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -30,6 +30,20 @@
     <div id="results-container"></div>
 </div>
 
+<div id="step2">
+    <h2>STEP 2: Process All</h2>
+    <label for="test-loop-depth">Test Loop Depth:</label><br>
+    <input type="number" id="test-loop-depth" name="test_loop_depth" min="1" max="5" value="1"><br><br>
+
+    <label for="gpt-instructions-step2">GPT Instructions:</label><br>
+    <textarea id="gpt-instructions-step2" name="gpt_instructions_step2" rows="4" cols="50"></textarea><br><br>
+
+    <button id="process-all">Process All</button>
+
+    <div id="step2-results-container"></div>
+</div>
+
 <script src="{{ url_for('static', filename='parse_locations/step1.js') }}"></script>
+<script src="{{ url_for('static', filename='parse_locations/step2.js') }}"></script>
 </body>
 </html>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -31,13 +31,14 @@
 </div>
 
 <div id="step2">
-    <h2>STEP 2: Process All</h2>
+    <h2>STEP 2: Process Results</h2>
     <label for="test-loop-depth">Test Loop Depth:</label><br>
     <input type="number" id="test-loop-depth" name="test_loop_depth" min="1" max="5" value="1"><br><br>
 
     <label for="gpt-instructions-step2">GPT Instructions:</label><br>
     <textarea id="gpt-instructions-step2" name="gpt_instructions_step2" rows="4" cols="50"></textarea><br><br>
 
+    <button id="process-single">Process Single</button>
     <button id="process-all">Process All</button>
 
     <div id="step2-results-container"></div>

--- a/frontend/js/parse_locations/step2.js
+++ b/frontend/js/parse_locations/step2.js
@@ -1,15 +1,7 @@
 console.log('step2.js loaded');
 
 $(document).ready(function () {
-    $('#process-all').on('click', function () {
-        const testLoopDepth = parseInt($('#test-loop-depth').val(), 10);
-        const instructions = $('#gpt-instructions-step2').val();
-
-        if (isNaN(testLoopDepth) || testLoopDepth < 1 || testLoopDepth > 5) {
-            alert('Test Loop Depth must be between 1 and 5');
-            return;
-        }
-
+    function gatherRows() {
         const rows = [];
         $('#results-table tr').each(function (index) {
             if (index === 0) return; // skip header
@@ -22,7 +14,64 @@ $(document).ready(function () {
                 result: result,
             });
         });
+        return rows;
+    }
 
+    function renderResults(results) {
+        let table = $('#step2-results-table');
+        if (table.length === 0) {
+            table = $('<table id="step2-results-table" border="1"></table>');
+            const header = $('<tr></tr>');
+            header.append('<th>Location</th>');
+            header.append('<th>Population</th>');
+            table.append(header);
+            $('#step2-results-container').append(table);
+        }
+
+        results.forEach(function (item) {
+            const row = $('<tr></tr>');
+            row.append($('<td></td>').text(item.location));
+            row.append($('<td></td>').text(item.population));
+            table.append(row);
+        });
+    }
+
+    $('#process-single').on('click', function () {
+        const testLoopDepth = parseInt($('#test-loop-depth').val(), 10);
+        const instructions = $('#gpt-instructions-step2').val();
+
+        if (isNaN(testLoopDepth) || testLoopDepth < 1 || testLoopDepth > 5) {
+            alert('Test Loop Depth must be between 1 and 5');
+            return;
+        }
+
+        const rows = gatherRows();
+        if (rows.length === 0) {
+            alert('No data to process.');
+            return;
+        }
+
+        $.ajax({
+            url: '/parse_locations/process_single',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                test_loop_depth: testLoopDepth,
+                instructions: instructions,
+                data: rows,
+            }),
+            success: function (data) {
+                renderResults(data.results || []);
+            },
+            error: function (xhr) {
+                alert(xhr.responseText);
+            },
+        });
+    });
+
+    $('#process-all').on('click', function () {
+        const instructions = $('#gpt-instructions-step2').val();
+        const rows = gatherRows();
         if (rows.length === 0) {
             alert('No data to process.');
             return;
@@ -33,29 +82,11 @@ $(document).ready(function () {
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({
-                test_loop_depth: testLoopDepth,
                 instructions: instructions,
                 data: rows,
             }),
             success: function (data) {
-                const results = data.results || [];
-
-                let table = $('#step2-results-table');
-                if (table.length === 0) {
-                    table = $('<table id="step2-results-table" border="1"></table>');
-                    const header = $('<tr></tr>');
-                    header.append('<th>Location</th>');
-                    header.append('<th>Population</th>');
-                    table.append(header);
-                    $('#step2-results-container').append(table);
-                }
-
-                results.forEach(function (item) {
-                    const row = $('<tr></tr>');
-                    row.append($('<td></td>').text(item.location));
-                    row.append($('<td></td>').text(item.population));
-                    table.append(row);
-                });
+                renderResults(data.results || []);
             },
             error: function (xhr) {
                 alert(xhr.responseText);

--- a/frontend/js/parse_locations/step2.js
+++ b/frontend/js/parse_locations/step2.js
@@ -22,16 +22,17 @@ $(document).ready(function () {
         if (table.length === 0) {
             table = $('<table id="step2-results-table" border="1"></table>');
             const header = $('<tr></tr>');
-            header.append('<th>Location</th>');
-            header.append('<th>Population</th>');
+            header.append('<th>Prompt</th>');
+            header.append('<th>Output</th>');
             table.append(header);
             $('#step2-results-container').append(table);
         }
 
         results.forEach(function (item) {
             const row = $('<tr></tr>');
-            row.append($('<td></td>').text(item.location));
-            row.append($('<td></td>').text(item.population));
+            row.append($('<td></td>').text(item.prompt));
+            const outputCell = $('<td></td>').html((item.output || '').replace(/\n/g, '<br>'));
+            row.append(outputCell);
             table.append(row);
         });
     }
@@ -51,6 +52,8 @@ $(document).ready(function () {
             return;
         }
 
+        const row = rows[0]; // process only the first row
+
         $.ajax({
             url: '/parse_locations/process_single',
             method: 'POST',
@@ -58,7 +61,7 @@ $(document).ready(function () {
             data: JSON.stringify({
                 test_loop_depth: testLoopDepth,
                 instructions: instructions,
-                data: rows,
+                data: [row],
             }),
             success: function (data) {
                 renderResults(data.results || []);


### PR DESCRIPTION
## Summary
- add step 2 interface with test loop depth, GPT instructions, and Process All button
- send step 1 table rows for batch processing and show location/population output
- support new processing with backend endpoint calling OpenAI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b1c893ec8333946879e9ea72ec1b