### PR TITLE
Add step 3 location parsing

### DIFF
--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -32,7 +32,14 @@
     <div id="step2-results-container"></div>
 </div>
 
+<div id="step3">
+    <h2>STEP 3: Parse Locations</h2>
+    <button id="parse-data">Parse Data</button>
+    <div id="step3-results-container"></div>
+</div>
+
 <script src="{{ url_for('static', filename='parse_locations/step1.js') }}"></script>
 <script src="{{ url_for('static', filename='parse_locations/step2.js') }}"></script>
+<script src="{{ url_for('static', filename='parse_locations/step3.js') }}"></script>
 </body>
 </html>

--- a/frontend/js/parse_locations/step3.js
+++ b/frontend/js/parse_locations/step3.js
@@ -1,0 +1,55 @@
+console.log('step3.js loaded');
+
+$(document).ready(function () {
+    $('#parse-data').on('click', function () {
+        const rows = [];
+
+        $('#step2-results-table tr').each(function (index) {
+            if (index === 0) return; // skip header
+            const baseLocation = $(this).find('td').eq(0).text().trim();
+            let rawData = $(this).find('td').eq(1).text();
+
+            // Remove code block markers
+            rawData = rawData.replace(/```json|```/g, '').trim();
+            // Remove block comments
+            rawData = rawData.replace(/\/\*[\s\S]*?\*\//g, '');
+
+            try {
+                const dataObj = JSON.parse(rawData);
+                Object.entries(dataObj).forEach(function ([key, value]) {
+                    rows.push({
+                        location: baseLocation + ' ' + key,
+                        population: value,
+                    });
+                });
+            } catch (e) {
+                console.error('Failed to parse JSON for', baseLocation, e);
+            }
+        });
+
+        if (rows.length === 0) {
+            alert('No data to parse.');
+            return;
+        }
+
+        let table = $('#step3-results-table');
+        if (table.length === 0) {
+            table = $('<table id="step3-results-table" border="1"></table>');
+            const header = $('<tr></tr>');
+            header.append('<th>Location</th>');
+            header.append('<th>Population</th>');
+            table.append(header);
+            $('#step3-results-container').append(table);
+        } else {
+            table.find('tr:gt(0)').remove();
+        }
+
+        rows.forEach(function (item) {
+            const row = $('<tr></tr>');
+            row.append($('<td></td>').text(item.location));
+            row.append($('<td></td>').text(item.population));
+            table.append(row);
+        });
+    });
+});
+


### PR DESCRIPTION
## Summary
- add "STEP 3" section to the parse locations page with a Parse Data button and results table
- implement `step3.js` to parse JSON from step 2 results, concatenate location names, and display population rows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689148b785988333af8feafc75090eaa