### PR TITLE
Add save and clear controls to Parse Locations steps

### DIFF
--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -16,6 +16,8 @@
         <small>This value is used to look up its population.</small><br><br>
 
         <button type="submit">Submit</button>
+        <button type="button" id="save-step1">Save Step 1</button>
+        <button type="button" id="clear-step1">Clear Step 1</button>
     </form>
 
     <div id="results-container"></div>
@@ -28,6 +30,8 @@
 
     <button id="process-single">Process Single</button>
     <button id="process-all">Process All</button>
+    <button type="button" id="save-step2">Save Step 2</button>
+    <button type="button" id="clear-step2">Clear Step 2</button>
 
     <div id="step2-results-container"></div>
 </div>
@@ -35,6 +39,8 @@
 <div id="step3">
     <h2>STEP 3: Parse Locations</h2>
     <button id="parse-data">Parse Data</button>
+    <button type="button" id="save-step3">Save Step 3</button>
+    <button type="button" id="clear-step3">Clear Step 3</button>
     <div id="step3-results-container"></div>
 </div>
 

--- a/frontend/js/parse_locations/step1.js
+++ b/frontend/js/parse_locations/step1.js
@@ -1,6 +1,37 @@
 console.log('step1.js loaded');
 
+function renderTable(rows, replace = false) {
+    let table = $('#results-table');
+    if (table.length === 0) {
+        table = $('<table id="results-table" border="1"></table>');
+        const header = $('<tr></tr>');
+        header.append('<th>Location</th>');
+        header.append('<th>Population</th>');
+        table.append(header);
+        $('#results-container').append(table);
+    }
+    if (replace) {
+        table.find('tr:gt(0)').remove();
+    }
+    rows.forEach(function (item) {
+        const row = $('<tr></tr>');
+        row.append($('<td></td>').text(item.location));
+        row.append($('<td></td>').text(item.population));
+        table.append(row);
+    });
+}
+
 $(document).ready(function () {
+    const saved = localStorage.getItem('parse_locations_step1');
+    if (saved) {
+        try {
+            const data = JSON.parse(saved);
+            renderTable(data, true);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
     $('#parse-locations-form').on('submit', function (event) {
         event.preventDefault();
 
@@ -16,26 +47,29 @@ $(document).ready(function () {
             success: function (data) {
                 const population = data.population;
                 const locationName = data.location_name;
-
-                let table = $('#results-table');
-                if (table.length === 0) {
-                    table = $('<table id="results-table" border="1"></table>');
-                    const header = $('<tr></tr>');
-                    header.append('<th>Location</th>');
-                    header.append('<th>Population</th>');
-                    table.append(header);
-                    $('#results-container').append(table);
-                }
-
-                const row = $('<tr></tr>');
-                row.append($('<td></td>').text(locationName));
-                row.append($('<td></td>').text(population));
-                table.append(row);
+                renderTable([{ location: locationName, population: population }]);
             },
             error: function (xhr) {
                 alert(xhr.responseText);
             }
         });
+    });
+
+    $('#save-step1').on('click', function () {
+        const rows = [];
+        $('#results-table tr').each(function (index) {
+            if (index === 0) return;
+            rows.push({
+                location: $(this).find('td').eq(0).text(),
+                population: $(this).find('td').eq(1).text(),
+            });
+        });
+        localStorage.setItem('parse_locations_step1', JSON.stringify(rows));
+    });
+
+    $('#clear-step1').on('click', function () {
+        $('#results-table').remove();
+        localStorage.removeItem('parse_locations_step1');
     });
 });
 

--- a/frontend/js/parse_locations/step2.js
+++ b/frontend/js/parse_locations/step2.js
@@ -1,6 +1,42 @@
 console.log('step2.js loaded');
 
+let step2Results = [];
+
+function renderResults(results, replace = false) {
+    let table = $('#step2-results-table');
+    if (table.length === 0) {
+        table = $('<table id="step2-results-table" border="1"></table>');
+        const header = $('<tr></tr>');
+        header.append('<th>Location</th>');
+        header.append('<th>Raw Data</th>');
+        table.append(header);
+        $('#step2-results-container').append(table);
+    }
+    if (replace) {
+        table.find('tr:gt(0)').remove();
+    }
+    results.forEach(function (item) {
+        const row = $('<tr></tr>');
+        row.append($('<td></td>').text(item.location));
+        const outputCell = $('<td></td>').html((item.raw_data || '').replace(/\n/g, '<br>'));
+        row.append(outputCell);
+        table.append(row);
+    });
+}
+
 $(document).ready(function () {
+    const saved = localStorage.getItem('parse_locations_step2');
+    if (saved) {
+        try {
+            const data = JSON.parse(saved);
+            $('#gpt-instructions-step2').val(data.instructions || '');
+            step2Results = data.results || [];
+            renderResults(step2Results, true);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
     function gatherRows() {
         const rows = [];
         $('#results-table tr').each(function (index) {
@@ -13,26 +49,6 @@ $(document).ready(function () {
             });
         });
         return rows;
-    }
-
-    function renderResults(results) {
-        let table = $('#step2-results-table');
-        if (table.length === 0) {
-            table = $('<table id="step2-results-table" border="1"></table>');
-            const header = $('<tr></tr>');
-            header.append('<th>Location</th>');
-            header.append('<th>Raw Data</th>');
-            table.append(header);
-            $('#step2-results-container').append(table);
-        }
-
-        results.forEach(function (item) {
-            const row = $('<tr></tr>');
-            row.append($('<td></td>').text(item.location));
-            const outputCell = $('<td></td>').html((item.raw_data || '').replace(/\n/g, '<br>'));
-            row.append(outputCell);
-            table.append(row);
-        });
     }
 
     $('#process-single').on('click', function () {
@@ -55,7 +71,9 @@ $(document).ready(function () {
                 data: [row],
             }),
             success: function (data) {
-                renderResults(data.results || []);
+                const res = data.results || [];
+                step2Results = step2Results.concat(res);
+                renderResults(res);
             },
             error: function (xhr) {
                 alert(xhr.responseText);
@@ -80,11 +98,26 @@ $(document).ready(function () {
                 data: rows,
             }),
             success: function (data) {
-                renderResults(data.results || []);
+                step2Results = data.results || [];
+                renderResults(step2Results, true);
             },
             error: function (xhr) {
                 alert(xhr.responseText);
             },
         });
     });
+
+    $('#save-step2').on('click', function () {
+        localStorage.setItem('parse_locations_step2', JSON.stringify({
+            instructions: $('#gpt-instructions-step2').val(),
+            results: step2Results,
+        }));
+    });
+
+    $('#clear-step2').on('click', function () {
+        $('#step2-results-table').remove();
+        step2Results = [];
+        localStorage.removeItem('parse_locations_step2');
+    });
 });
+

--- a/frontend/js/parse_locations/step3.js
+++ b/frontend/js/parse_locations/step3.js
@@ -1,6 +1,39 @@
 console.log('step3.js loaded');
 
+let step3Results = [];
+
+function renderTable(rows, replace = false) {
+    let table = $('#step3-results-table');
+    if (table.length === 0) {
+        table = $('<table id="step3-results-table" border="1"></table>');
+        const header = $('<tr></tr>');
+        header.append('<th>Location</th>');
+        header.append('<th>Population</th>');
+        table.append(header);
+        $('#step3-results-container').append(table);
+    }
+    if (replace) {
+        table.find('tr:gt(0)').remove();
+    }
+    rows.forEach(function (item) {
+        const row = $('<tr></tr>');
+        row.append($('<td></td>').text(item.location));
+        row.append($('<td></td>').text(item.population));
+        table.append(row);
+    });
+}
+
 $(document).ready(function () {
+    const saved = localStorage.getItem('parse_locations_step3');
+    if (saved) {
+        try {
+            step3Results = JSON.parse(saved) || [];
+            renderTable(step3Results, true);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
     $('#parse-data').on('click', function () {
         const rows = [];
 
@@ -9,9 +42,7 @@ $(document).ready(function () {
             const baseLocation = $(this).find('td').eq(0).text().trim();
             let rawData = $(this).find('td').eq(1).text();
 
-            // Remove code block markers
             rawData = rawData.replace(/```json|```/g, '').trim();
-            // Remove block comments
             rawData = rawData.replace(/\/\*[\s\S]*?\*\//g, '');
 
             try {
@@ -32,24 +63,18 @@ $(document).ready(function () {
             return;
         }
 
-        let table = $('#step3-results-table');
-        if (table.length === 0) {
-            table = $('<table id="step3-results-table" border="1"></table>');
-            const header = $('<tr></tr>');
-            header.append('<th>Location</th>');
-            header.append('<th>Population</th>');
-            table.append(header);
-            $('#step3-results-container').append(table);
-        } else {
-            table.find('tr:gt(0)').remove();
-        }
+        step3Results = rows;
+        renderTable(step3Results, true);
+    });
 
-        rows.forEach(function (item) {
-            const row = $('<tr></tr>');
-            row.append($('<td></td>').text(item.location));
-            row.append($('<td></td>').text(item.population));
-            table.append(row);
-        });
+    $('#save-step3').on('click', function () {
+        localStorage.setItem('parse_locations_step3', JSON.stringify(step3Results));
+    });
+
+    $('#clear-step3').on('click', function () {
+        $('#step3-results-table').remove();
+        step3Results = [];
+        localStorage.removeItem('parse_locations_step3');
     });
 });
 


### PR DESCRIPTION
## Summary
- Add Save/Clear buttons for each step of the Parse Locations UI
- Persist step data in localStorage so users can restore inputs and results
- Allow clearing persisted data for individual steps

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68916ad1888c8333b02a10ec2e804b2e