### PR TITLE
Add navigation bar and default contact prompt

### DIFF
--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -12,6 +12,11 @@
 </head>
 <body>
 <h1>SFA Lead Generator</h1>
+<nav>
+    <a href="{{ url_for('step1.index') }}">Home</a> |
+    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a>
+</nav>
 
 <div id="step1">
     <h2>STEP 1: Initial Data Load</h2>
@@ -32,7 +37,7 @@
         <label>Instructions:</label><br>
         <textarea id="instructions" style="height:80px;"></textarea><br>
         <label>Prompt (use column names in {braces}):</label><br>
-        <input type="text" id="prompt" style="width:100%;" placeholder="e.g. Summarize {name}"><br>
+          <textarea id="prompt" style="height:200px;"></textarea><br>
         <label>Row index for single run:</label>
         <input type="number" id="row-index" value="0" min="0"><br>
         <button id="process-single-btn">Process Single Row</button>

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -14,8 +14,8 @@
 <h1>SFA Lead Generator</h1>
 <nav>
     <a href="{{ url_for('step1.index') }}">Home</a> |
-    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
-    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a>
+    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
 </nav>
 
 <div id="step1">

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -6,7 +6,11 @@
 </head>
 <body>
 <h1>SFA Lead Generator</h1>
-<p><a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a></p>
-<p><a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a></p>
+<nav>
+    <a href="{{ url_for('step1.index') }}">Home</a> |
+    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a>
+ </nav>
+ <p>Welcome to SFA Lead Generator.</p>
 </body>
 </html>

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -8,9 +8,9 @@
 <h1>SFA Lead Generator</h1>
 <nav>
     <a href="{{ url_for('step1.index') }}">Home</a> |
-    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
-    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a>
- </nav>
+    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+</nav>
  <p>Welcome to SFA Lead Generator.</p>
 </body>
 </html>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -9,8 +9,8 @@
 <h1>Parse Locations</h1>
 <nav>
     <a href="{{ url_for('step1.index') }}">Home</a> |
-    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
-    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a>
+    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
 </nav>
 
 <div id="step1">

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -7,6 +7,11 @@
 </head>
 <body>
 <h1>Parse Locations</h1>
+<nav>
+    <a href="{{ url_for('step1.index') }}">Home</a> |
+    <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a>
+</nav>
 
 <div id="step1">
     <h2>STEP 1: Setup</h2>

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -106,7 +106,7 @@ $("#process-single-btn").on("click", function () {
 });
 
 $(document).ready(function () {
-  var defaultPrompt = `You are a contact generation expert for sales.  
+  var defaultInstructions = `You are a contact generation expert for sales.
 
 For the business provided, find all key contacts. Prioritize:  
 – Founders  
@@ -137,7 +137,7 @@ Example output:
   { "firstname": "Laura", "lastname": "Nguyen", "role": "VP of Operations", "email": "laura.nguyen@abccompany.com" },
   { "firstname": "Carlos", "lastname": "Rivera", "role": "COO", "email": "carlos.rivera@abccompany.com" }
 ]`;
-  $("#prompt").val(defaultPrompt);
+  $("#instructions").val(defaultInstructions);
 
   var saved = localStorage.getItem("saved_results");
   if (saved) {

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -106,6 +106,39 @@ $("#process-single-btn").on("click", function () {
 });
 
 $(document).ready(function () {
+  var defaultPrompt = `You are a contact generation expert for sales.  
+
+For the business provided, find all key contacts. Prioritize:  
+– Founders  
+– COOs  
+– Heads of Operations  
+– Other senior decision-makers  
+
+Required output format:  
+Return results as a JSON array of objects.  
+Each object must contain:  
+- firstname  
+- lastname  
+- role
+- email (if you can't find their email directly guess it)
+
+⚠️ Do not include company name, emails, or any extra explanation.  
+⚠️ Output only the raw JSON.
+
+Example input:  
+ABC Company
+
+Example output:
+[
+  { "firstname": "John", "lastname": "Smith", "role": "Founder", "email": "john.smith@abccompany.com" },
+  { "firstname": "Jane", "lastname": "Doe", "role": "COO", "email": "jane.doe@abccompany.com" },
+  { "firstname": "Michael", "lastname": "Johnson", "role": "Head of Operations", "email": "michael.johnson@abccompany.com" },
+  { "firstname": "Ryan", "lastname": "Patel", "role": "Founder", "email": "ryan.patel@abccompany.com" },
+  { "firstname": "Laura", "lastname": "Nguyen", "role": "VP of Operations", "email": "laura.nguyen@abccompany.com" },
+  { "firstname": "Carlos", "lastname": "Rivera", "role": "COO", "email": "carlos.rivera@abccompany.com" }
+]`;
+  $("#prompt").val(defaultPrompt);
+
   var saved = localStorage.getItem("saved_results");
   if (saved) {
     try {


### PR DESCRIPTION
## Summary
- add site-wide nav links between home, Generate Contacts, and Parse Locations pages
- default contact generation prompt now pre-filled on the Generate Contacts workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68935cddd3208333a463353b00d087c4