### PR TITLE
Refactor parse_locations backend into modular steps

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,12 @@ from dotenv import load_dotenv
 import openai
 
 from backend.generate_contacts import step1_bp, step2_bp, step3_bp
-from backend.parse_locations import parse_locations_bp
+from backend.parse_locations import (
+    step1_bp as parse_step1_bp,
+    step2_bp as parse_step2_bp,
+    step3_bp as parse_step3_bp,
+    step4_bp as parse_step4_bp,
+)
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -17,7 +22,10 @@ def create_app():
     app.register_blueprint(step1_bp)
     app.register_blueprint(step2_bp)
     app.register_blueprint(step3_bp)
-    app.register_blueprint(parse_locations_bp)
+    app.register_blueprint(parse_step1_bp)
+    app.register_blueprint(parse_step2_bp)
+    app.register_blueprint(parse_step3_bp)
+    app.register_blueprint(parse_step4_bp)
 
     return app
 

--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -1,107 +1,14 @@
-"""Routes and helpers for parsing location data via GPT."""
+"""Blueprint registrations for the parse_locations feature."""
 
-import json
-from typing import Dict, List
+from .step1 import step1_bp
+from .step2 import step2_bp
+from .step3 import step3_bp
+from .step4 import step4_bp
 
-from flask import Blueprint, jsonify, render_template, request
-
-from ..utilities.openai_helpers import call_openai
-
-
-parse_locations_bp = Blueprint("parse_locations", __name__)
-
-
-# ---------------------------------------------------------------------------
-# Helper functions
-# ---------------------------------------------------------------------------
-
-POPULATION_SCHEMA = {
-    "name": "population_schema",
-    "schema": {
-        "type": "object",
-        "properties": {"population": {"type": "integer"}},
-        "required": ["population"],
-        "additionalProperties": False,
-    },
-}
-
-POPULATION_INSTRUCTIONS = (
-    "Return the population for the given location as JSON following the provided schema."
-)
-
-
-def _parse_population(raw_result: str) -> int:
-    """Extract an integer population value from the raw GPT response."""
-    try:
-        parsed = json.loads(raw_result)
-        return int(str(parsed.get("population", "")).replace(",", ""))
-    except Exception:
-        return 0
-
-
-def _request_population(location: str) -> int:
-    """Query GPT for the population of a location and return it as an integer."""
-    message = f"Location: {location}"
-    raw_result = call_openai(
-        POPULATION_INSTRUCTIONS,
-        message,
-        model="gpt-4o",
-        temperature=0,
-        response_format={"type": "json_schema", "json_schema": POPULATION_SCHEMA},
-    )
-    return _parse_population(raw_result)
-
-
-def _build_prompt(location: str, population: str) -> str:
-    """Create the prompt used for custom GPT queries."""
-    return f"Location: {location}\nPopulation: {population}"
-
-
-def _process_entry(instructions: str, entry: Dict[str, str]) -> Dict[str, str]:
-    """Call GPT for a single entry and return the raw result."""
-    location = entry.get("location", "")
-    population = entry.get("population", "")
-    prompt = _build_prompt(location, population)
-    raw_data = call_openai(instructions, prompt, model="gpt-4o")
-    return {"location": location, "raw_data": raw_data}
-
-
-# ---------------------------------------------------------------------------
-# Routes
-# ---------------------------------------------------------------------------
-
-
-@parse_locations_bp.route("/parse_locations")
-def parse_locations() -> str:
-    """Render the parse locations page."""
-    return render_template("parse_locations.html")
-
-
-@parse_locations_bp.route("/parse_locations/run_instructions", methods=["POST"])
-def run_instructions():
-    """Look up the population for a location using a fixed GPT prompt."""
-    payload = request.json or {}
-    location = payload.get("location", payload.get("prompt", ""))
-    population = _request_population(location)
-    return jsonify({"location_name": location, "population": population})
-
-
-@parse_locations_bp.route("/parse_locations/process_single", methods=["POST"])
-def process_single():
-    """Query a single location and capture the raw GPT output."""
-    payload = request.json or {}
-    instructions = payload.get("instructions", "")
-    data: List[Dict[str, str]] = payload.get("data", [])
-    results = [_process_entry(instructions, data[0])] if data else []
-    return jsonify({"results": results})
-
-
-@parse_locations_bp.route("/parse_locations/process_all", methods=["POST"])
-def process_all():
-    """Query all rows and return raw GPT output for each location."""
-    payload = request.json or {}
-    instructions = payload.get("instructions", "")
-    data: List[Dict[str, str]] = payload.get("data", [])
-    results = [_process_entry(instructions, entry) for entry in data]
-    return jsonify({"results": results})
+__all__ = [
+    "step1_bp",
+    "step2_bp",
+    "step3_bp",
+    "step4_bp",
+]
 

--- a/backend/parse_locations/processing.py
+++ b/backend/parse_locations/processing.py
@@ -1,0 +1,62 @@
+"""Helper functions for the parse_locations feature."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from ..utilities.openai_helpers import call_openai
+
+POPULATION_SCHEMA = {
+    "name": "population_schema",
+    "schema": {
+        "type": "object",
+        "properties": {"population": {"type": "integer"}},
+        "required": ["population"],
+        "additionalProperties": False,
+    },
+}
+
+POPULATION_INSTRUCTIONS = (
+    "Return the population for the given location as JSON following the provided schema."
+)
+
+
+def _parse_population(raw_result: str) -> int:
+    """Extract an integer population value from the raw GPT response."""
+    try:
+        parsed = json.loads(raw_result)
+        return int(str(parsed.get("population", "")).replace(",", ""))
+    except Exception:
+        return 0
+
+
+def request_population(location: str) -> int:
+    """Query GPT for the population of a location and return it as an integer."""
+    message = f"Location: {location}"
+    raw_result = call_openai(
+        POPULATION_INSTRUCTIONS,
+        message,
+        model="gpt-4o",
+        temperature=0,
+        response_format={"type": "json_schema", "json_schema": POPULATION_SCHEMA},
+    )
+    return _parse_population(raw_result)
+
+
+def _build_prompt(location: str, population: str) -> str:
+    """Create the prompt used for custom GPT queries."""
+    return f"Location: {location}\nPopulation: {population}"
+
+
+def process_entry(instructions: str, entry: Dict[str, str]) -> Dict[str, str]:
+    """Call GPT for a single entry and return the raw result."""
+    location = entry.get("location", "")
+    population = entry.get("population", "")
+    prompt = _build_prompt(location, population)
+    raw_data = call_openai(instructions, prompt, model="gpt-4o")
+    return {"location": location, "raw_data": raw_data}
+
+
+__all__ = ["request_population", "process_entry"]
+

--- a/backend/parse_locations/step1.py
+++ b/backend/parse_locations/step1.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+
+
+step1_bp = Blueprint("parse_locations_step1", __name__)
+
+
+@step1_bp.route("/parse_locations")
+def parse_locations():
+    """Render the parse locations page."""
+    return render_template("parse_locations.html")
+

--- a/backend/parse_locations/step2.py
+++ b/backend/parse_locations/step2.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, jsonify, request
+
+from .processing import request_population
+
+
+step2_bp = Blueprint("parse_locations_step2", __name__)
+
+
+@step2_bp.route("/parse_locations/run_instructions", methods=["POST"])
+def run_instructions():
+    """Look up the population for a location using a fixed GPT prompt."""
+    payload = request.json or {}
+    location = payload.get("location", payload.get("prompt", ""))
+    population = request_population(location)
+    return jsonify({"location_name": location, "population": population})
+

--- a/backend/parse_locations/step3.py
+++ b/backend/parse_locations/step3.py
@@ -1,0 +1,19 @@
+from typing import Dict, List
+
+from flask import Blueprint, jsonify, request
+
+from .processing import process_entry
+
+
+step3_bp = Blueprint("parse_locations_step3", __name__)
+
+
+@step3_bp.route("/parse_locations/process_single", methods=["POST"])
+def process_single():
+    """Query a single location and capture the raw GPT output."""
+    payload = request.json or {}
+    instructions = payload.get("instructions", "")
+    data: List[Dict[str, str]] = payload.get("data", [])
+    results = [process_entry(instructions, data[0])] if data else []
+    return jsonify({"results": results})
+

--- a/backend/parse_locations/step4.py
+++ b/backend/parse_locations/step4.py
@@ -1,0 +1,19 @@
+from typing import Dict, List
+
+from flask import Blueprint, jsonify, request
+
+from .processing import process_entry
+
+
+step4_bp = Blueprint("parse_locations_step4", __name__)
+
+
+@step4_bp.route("/parse_locations/process_all", methods=["POST"])
+def process_all():
+    """Query all rows and return raw GPT output for each location."""
+    payload = request.json or {}
+    instructions = payload.get("instructions", "")
+    data: List[Dict[str, str]] = payload.get("data", [])
+    results = [process_entry(instructions, entry) for entry in data]
+    return jsonify({"results": results})
+


### PR DESCRIPTION
## Summary
- refactor parse_locations backend into four modular step blueprints
- centralize shared helper logic in new processing module
- register new parse_locations blueprints in app initialization

## Testing
- `python -m py_compile backend/parse_locations/__init__.py backend/parse_locations/processing.py backend/parse_locations/step1.py backend/parse_locations/step2.py backend/parse_locations/step3.py backend/parse_locations/step4.py`
- `python -m py_compile app.py backend/generate_contacts/__init__.py backend/generate_contacts/processing.py backend/generate_contacts/step1.py backend/generate_contacts/step2.py backend/generate_contacts/step3.py backend/generate_contacts/data_store.py`


------
https://chatgpt.com/codex/tasks/task_e_689366387124833382dcb320ebf59aa0