### PR TITLE
Rename parse_locations blueprint and update links

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 import openai
 
 from backend.generate_contacts import step1_bp, step2_bp, step3_bp
-from backend.parse_locations import parse_locations_bp
+from backend.parse_locations import parse_locations_step1_bp
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -17,7 +17,7 @@ def create_app():
     app.register_blueprint(step1_bp)
     app.register_blueprint(step2_bp)
     app.register_blueprint(step3_bp)
-    app.register_blueprint(parse_locations_bp)
+    app.register_blueprint(parse_locations_step1_bp)
 
     return app
 

--- a/backend/parse_locations/__init__.py
+++ b/backend/parse_locations/__init__.py
@@ -8,7 +8,7 @@ from flask import Blueprint, jsonify, render_template, request
 from ..utilities.openai_helpers import call_openai
 
 
-parse_locations_bp = Blueprint("parse_locations", __name__)
+parse_locations_step1_bp = Blueprint("parse_locations_step1", __name__)
 
 
 # ---------------------------------------------------------------------------
@@ -71,13 +71,13 @@ def _process_entry(instructions: str, entry: Dict[str, str]) -> Dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-@parse_locations_bp.route("/parse_locations")
+@parse_locations_step1_bp.route("/parse_locations")
 def parse_locations() -> str:
     """Render the parse locations page."""
     return render_template("parse_locations.html")
 
 
-@parse_locations_bp.route("/parse_locations/run_instructions", methods=["POST"])
+@parse_locations_step1_bp.route("/parse_locations/run_instructions", methods=["POST"])
 def run_instructions():
     """Look up the population for a location using a fixed GPT prompt."""
     payload = request.json or {}
@@ -86,7 +86,7 @@ def run_instructions():
     return jsonify({"location_name": location, "population": population})
 
 
-@parse_locations_bp.route("/parse_locations/process_single", methods=["POST"])
+@parse_locations_step1_bp.route("/parse_locations/process_single", methods=["POST"])
 def process_single():
     """Query a single location and capture the raw GPT output."""
     payload = request.json or {}
@@ -96,7 +96,7 @@ def process_single():
     return jsonify({"results": results})
 
 
-@parse_locations_bp.route("/parse_locations/process_all", methods=["POST"])
+@parse_locations_step1_bp.route("/parse_locations/process_all", methods=["POST"])
 def process_all():
     """Query all rows and return raw GPT output for each location."""
     payload = request.json or {}

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -14,7 +14,7 @@
 <h1>SFA Lead Generator</h1>
 <nav>
     <a href="{{ url_for('step1.index') }}">Home</a> |
-    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+    <a href="{{ url_for('parse_locations_step1.parse_locations') }}">Parse Locations</a> |
     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
 </nav>
 

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -8,7 +8,7 @@
 <h1>SFA Lead Generator</h1>
 <nav>
     <a href="{{ url_for('step1.index') }}">Home</a> |
-    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+    <a href="{{ url_for('parse_locations_step1.parse_locations') }}">Parse Locations</a> |
     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
 </nav>
  <p>Welcome to SFA Lead Generator.</p>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -9,7 +9,7 @@
 <h1>Parse Locations</h1>
 <nav>
     <a href="{{ url_for('step1.index') }}">Home</a> |
-    <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+    <a href="{{ url_for('parse_locations_step1.parse_locations') }}">Parse Locations</a> |
     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
 </nav>
 


### PR DESCRIPTION
## Summary
- rename parse_locations blueprint to parse_locations_step1
- adjust Flask app registration for new blueprint name
- update navigation links to use parse_locations_step1

## Testing
- `python -m py_compile app.py backend/parse_locations/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6893692154d48333a80d43d91bf16dde