### PR TITLE
Fix Parse Locations blueprint reference mismatch

### DIFF
--- a/backend/parse_locations/step1.py
+++ b/backend/parse_locations/step1.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template
 
 
-step1_bp = Blueprint("parse_locations_step1", __name__)
+step1_bp = Blueprint("parse_locations", __name__)
 
 
 @step1_bp.route("/parse_locations")


### PR DESCRIPTION
## Summary
- Rename `parse_locations_step1` blueprint to `parse_locations` so existing template links resolve correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68936c2304f48333aa71642661769160