### PR TITLE
Improve find businesses workflow and parsing

### DIFF
--- a/backend/find_businesses/processing.py
+++ b/backend/find_businesses/processing.py
@@ -27,8 +27,8 @@ def _strip_json_codeblock(text: str) -> str:
     return text
 
 
-def parse_contacts(raw_result: str):
-    """Return a list of contact dicts parsed from the raw OpenAI result."""
+def parse_businesses(raw_result: str):
+    """Return a list of business dicts parsed from the raw OpenAI result."""
     try:
         return json.loads(raw_result)
     except json.JSONDecodeError:
@@ -39,53 +39,26 @@ def parse_contacts(raw_result: str):
             return []
 
 
-def _normalize_contact(contact: dict) -> dict:
-    """Return a new contact dict with common fields normalized."""
-    normalized = {}
-    for key, value in contact.items():
-        lower = key.lower().strip().replace(" ", "_")
-        if "email" in lower:
-            # Collapse any key containing the word "email" to just "email"
-            normalized["email"] = value
-        else:
-            normalized[key] = value
-    return normalized
-
-
-def _extract_business_name(row: dict):
-    """Try to guess the business name column from the given row."""
-    for key, value in row.items():
-        lower = key.lower().replace("_", " ")
-        if "business" in lower and "name" in lower:
-            return value
-    return row.get("name")
-
-
-def parse_results_to_contacts(results):
+def parse_results_to_businesses(results):
     """Parse the 'result' field from each row of step 2 output.
 
-    In addition to the contacts extracted from the JSON ``result`` field, all
-    other columns from the Step 2 table are carried over so that downstream
-    steps have full context for each contact.
+    Each business object extracted from the JSON ``result`` field is combined
+    with the non-result columns from the Step 2 table so downstream steps have
+    full context for each business.
     """
-    contacts = []
+    businesses = []
     for row in results:
         if isinstance(row, dict):
             raw = row.get("result", "")
             base_data = {k: v for k, v in row.items() if k != "result"}
-            business_name = _extract_business_name(row)
         else:
             raw = str(row)
             base_data = {}
-            business_name = None
 
-        for contact in parse_contacts(raw):
-            normalized = _normalize_contact(contact)
-            contact_data = {**base_data, **normalized}
-            if business_name is not None:
-                contact_data.setdefault("business_name", business_name)
-            contacts.append(contact_data)
-    return contacts
+        for business in parse_businesses(raw):
+            business_data = {**base_data, **business}
+            businesses.append(business_data)
+    return businesses
 
 
 def apply_prompt_to_dataframe(df: pd.DataFrame, instructions: str, prompt: str):

--- a/backend/find_businesses/step3.py
+++ b/backend/find_businesses/step3.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request
 
-from .processing import parse_results_to_contacts
+from .processing import parse_results_to_businesses
 
 # Blueprint for Step 3 of Find Businesses
 step3_bp = Blueprint("find_businesses_step3", __name__)
@@ -8,7 +8,7 @@ step3_bp = Blueprint("find_businesses_step3", __name__)
 
 @step3_bp.route("/find_businesses/parse_contacts", methods=["POST"])
 def parse_contacts_endpoint():
-    """Parse Step 2 results into contact rows."""
+    """Parse Step 2 results into business rows."""
     results = request.json.get("results", [])
-    contacts = parse_results_to_contacts(results)
-    return jsonify(contacts)
+    businesses = parse_results_to_businesses(results)
+    return jsonify(businesses)

--- a/backend/utilities/openai_helpers.py
+++ b/backend/utilities/openai_helpers.py
@@ -31,8 +31,11 @@ def call_openai(
 
         extra_args: Dict[str, Any] = {}
         if "search" in model:
+            # Search models currently reject the ``temperature`` parameter.
+            # Skip including it while still enabling web search options.
             extra_args["web_search_options"] = {}
-        extra_args["temperature"] = temperature
+        else:
+            extra_args["temperature"] = temperature
         if response_format:
             extra_args["response_format"] = response_format
 

--- a/frontend/js/find_businesses/step2.js
+++ b/frontend/js/find_businesses/step2.js
@@ -106,37 +106,17 @@ function addOrUpdateResultRow(rowData, index) {
 });
 
 $(document).ready(function () {
-  var defaultInstructions = `You are a contact generation expert for sales.
+  var defaultInstructions = `You are a business finder expert for sales.
 
-For the business provided, find all key contacts. Prioritize:  
-– Founders  
-– COOs  
-– Heads of Operations  
-– Other senior decision-makers  
+  For the location provided, find all types of mortgage broker businesses. search like a CIA pro to find every business in the area.
 
-Required output format:  
+  Required output format:
 Return results as a JSON array of objects.  
 Each object must contain:  
-- firstname  
-- lastname  
-- role
-- email (if you can't find their email directly guess it)
+- business_name  
+- website
 
-⚠️ Do not include company name, emails, or any extra explanation.  
-⚠️ Output only the raw JSON.
-
-Example input:  
-ABC Company
-
-Example output:
-[
-  { "firstname": "John", "lastname": "Smith", "role": "Founder", "email": "john.smith@abccompany.com" },
-  { "firstname": "Jane", "lastname": "Doe", "role": "COO", "email": "jane.doe@abccompany.com" },
-  { "firstname": "Michael", "lastname": "Johnson", "role": "Head of Operations", "email": "michael.johnson@abccompany.com" },
-  { "firstname": "Ryan", "lastname": "Patel", "role": "Founder", "email": "ryan.patel@abccompany.com" },
-  { "firstname": "Laura", "lastname": "Nguyen", "role": "VP of Operations", "email": "laura.nguyen@abccompany.com" },
-  { "firstname": "Carlos", "lastname": "Rivera", "role": "COO", "email": "carlos.rivera@abccompany.com" }
-]`;
+DO NOT return any explanation, description, or formatting outside the JSON.`;
   $("#instructions").val(defaultInstructions);
 
   var saved = localStorage.getItem("saved_results");

--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -1,20 +1,20 @@
-var parsedContacts = [];
+var parsedBusinesses = [];
 
 $(document).ready(function () {
-  var saved = localStorage.getItem("saved_contacts");
+  var saved = localStorage.getItem("saved_businesses");
   if (saved) {
     try {
-      parsedContacts = JSON.parse(saved);
-      renderContactsTable(parsedContacts);
+      parsedBusinesses = JSON.parse(saved);
+      renderBusinessesTable(parsedBusinesses);
     } catch (e) {
       console.error(e);
     }
   }
 });
 
-function renderContactsTable(data) {
+function renderBusinessesTable(data) {
   if (!data.length) {
-    $("#contacts-container").html("No contacts");
+    $("#contacts-container").html("No businesses");
     return;
   }
   var cols = Object.keys(data[0]);
@@ -44,14 +44,14 @@ $("#parse-btn").on("click", function () {
     alert("No Step 2 results to parse");
     return;
   }
-    $.ajax({
-      url: "/find_businesses/parse_contacts",
-      method: "POST",
+  $.ajax({
+    url: "/find_businesses/parse_contacts",
+    method: "POST",
     contentType: "application/json",
     data: JSON.stringify({ results: step2Results }),
     success: function (data) {
-      parsedContacts = data;
-      renderContactsTable(data);
+      parsedBusinesses = data;
+      renderBusinessesTable(data);
     },
     error: function (xhr) {
       alert(xhr.responseText);
@@ -60,5 +60,5 @@ $("#parse-btn").on("click", function () {
 });
 
 $("#save-setup-btn").on("click", function () {
-  localStorage.setItem("saved_contacts", JSON.stringify(parsedContacts));
+  localStorage.setItem("saved_businesses", JSON.stringify(parsedBusinesses));
 });


### PR DESCRIPTION
## Summary
- avoid sending temperature to search models that reject it
- default instructions to locate mortgage brokers with business_name and website
- parse step2 results into businesses and show them in step3

## Testing
- `python -m py_compile backend/utilities/openai_helpers.py backend/find_businesses/processing.py backend/find_businesses/step3.py`


------
https://chatgpt.com/codex/tasks/task_e_6894d3ce41488333bbb520f48cd68e47