### PR TITLE
Persist step3 results across pages

### DIFF
--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -50,8 +50,9 @@ $("#parse-btn").on("click", function () {
     contentType: "application/json",
     data: JSON.stringify({ results: step2Results }),
     success: function (data) {
-      parsedBusinesses = data;
-      renderBusinessesTable(data);
+      parsedBusinesses = parsedBusinesses.concat(data);
+      renderBusinessesTable(parsedBusinesses);
+      localStorage.setItem("saved_businesses", JSON.stringify(parsedBusinesses));
     },
     error: function (xhr) {
       alert(xhr.responseText);

--- a/frontend/js/generate_contacts/step3.js
+++ b/frontend/js/generate_contacts/step3.js
@@ -50,8 +50,9 @@ $("#parse-btn").on("click", function () {
     contentType: "application/json",
     data: JSON.stringify({ results: step2Results }),
     success: function (data) {
-      parsedContacts = data;
-      renderContactsTable(data);
+      parsedContacts = parsedContacts.concat(data);
+      renderContactsTable(parsedContacts);
+      localStorage.setItem("saved_contacts", JSON.stringify(parsedContacts));
     },
     error: function (xhr) {
       alert(xhr.responseText);

--- a/frontend/js/parse_locations/step3.js
+++ b/frontend/js/parse_locations/step3.js
@@ -65,6 +65,7 @@ $(document).ready(function () {
 
         step3Results = rows;
         renderStep3Table(step3Results, true);
+        localStorage.setItem('parse_locations_step3', JSON.stringify(step3Results));
     });
 
     $('#save-step3').on('click', function () {


### PR DESCRIPTION
## Summary
- Append parsed businesses to existing results and auto-save to storage
- Auto-save parsed location results
- Append parsed contacts to existing results and auto-save

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68966d955864833386ec8e4ecf8ca478