### PR TITLE
Auto-save step inputs and prompts

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -38,7 +38,7 @@
         <label>Instructions:</label><br>
         <textarea id="instructions" style="height:80px;"></textarea><br>
         <label>Prompt (use column names in {braces}):</label><br>
-          <textarea id="prompt" style="height:200px;"></textarea><br>
+          <textarea id="prompt" style="height:100px;"></textarea><br>
         <label>Row index for single run:</label>
         <input type="number" id="row-index" value="0" min="0"><br>
         <button id="process-single-btn">Process Single Row</button>

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -38,7 +38,7 @@
         <label>Instructions:</label><br>
         <textarea id="instructions" style="height:80px;"></textarea><br>
         <label>Prompt (use column names in {braces}):</label><br>
-          <textarea id="prompt" style="height:200px;"></textarea><br>
+          <textarea id="prompt" style="height:100px;"></textarea><br>
         <label>Row index for single run:</label>
         <input type="number" id="row-index" value="0" min="0"><br>
         <button id="process-single-btn">Process Single Row</button>

--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -33,8 +33,16 @@ function autoPopulateFromSaved() {
   }
 }
 
+function autoSave() {
+  localStorage.setItem("saved_tsv", $("#tsv-input").val());
+  localStorage.setItem("saved_instructions", $("#instructions").val());
+  localStorage.setItem("saved_prompt", $("#prompt").val());
+}
+
 $(document).ready(function () {
   autoPopulateFromSaved();
+  $("#tsv-input, #instructions, #prompt").on("input", autoSave);
+  $(window).on("beforeunload", autoSave);
 });
 
 $("#upload-form").on("submit", function (e) {
@@ -48,6 +56,7 @@ $("#upload-form").on("submit", function (e) {
     contentType: false,
     success: function (data) {
       renderDataTable(JSON.parse(data));
+      autoSave();
     },
     error: function (xhr) {
       alert(xhr.responseText);

--- a/frontend/js/find_businesses/step2.js
+++ b/frontend/js/find_businesses/step2.js
@@ -75,6 +75,7 @@ function addOrUpdateResultRow(rowData, index) {
       console.log("Raw data from backend:", data);
       step2Results = data;
       renderResultsTable(data);
+      localStorage.setItem("saved_results", JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
@@ -98,14 +99,15 @@ function addOrUpdateResultRow(rowData, index) {
     success: function (data) {
       step2Results[rowIndex] = data;
       addOrUpdateResultRow(data, rowIndex);
+      localStorage.setItem("saved_results", JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
     },
   });
-});
+  });
 
-$(document).ready(function () {
+  $(document).ready(function () {
   var defaultInstructions = `You are a business finder expert for sales.
 
   For the location provided, find all types of mortgage broker businesses. search like a CIA pro to find every business in the area.
@@ -118,6 +120,15 @@ Each object must contain:
 
 DO NOT return any explanation, description, or formatting outside the JSON.`;
   $("#instructions").val(defaultInstructions);
+  var savedPrompt = localStorage.getItem("find_businesses_step2_prompt");
+  if (savedPrompt && savedPrompt.trim() !== "") {
+    $("#prompt").val(savedPrompt);
+  } else {
+    $("#prompt").val("{Locations}");
+  }
+  $("#prompt").on("input", function () {
+    localStorage.setItem("find_businesses_step2_prompt", $(this).val());
+  });
 
   var saved = localStorage.getItem("saved_results");
   if (saved) {
@@ -130,6 +141,7 @@ DO NOT return any explanation, description, or formatting outside the JSON.`;
   }
 });
 
-$("#save-setup-btn").on("click", function () {
+$(window).on("beforeunload", function () {
+  localStorage.setItem("find_businesses_step2_prompt", $("#prompt").val());
   localStorage.setItem("saved_results", JSON.stringify(step2Results));
 });

--- a/frontend/js/generate_contacts/step1.js
+++ b/frontend/js/generate_contacts/step1.js
@@ -33,8 +33,16 @@ function autoPopulateFromSaved() {
   }
 }
 
+function autoSave() {
+  localStorage.setItem("saved_tsv", $("#tsv-input").val());
+  localStorage.setItem("saved_instructions", $("#instructions").val());
+  localStorage.setItem("saved_prompt", $("#prompt").val());
+}
+
 $(document).ready(function () {
   autoPopulateFromSaved();
+  $("#tsv-input, #instructions, #prompt").on("input", autoSave);
+  $(window).on("beforeunload", autoSave);
 });
 
 $("#upload-form").on("submit", function (e) {
@@ -48,6 +56,7 @@ $("#upload-form").on("submit", function (e) {
     contentType: false,
     success: function (data) {
       renderDataTable(JSON.parse(data));
+      autoSave();
     },
     error: function (xhr) {
       alert(xhr.responseText);

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -75,6 +75,7 @@ $("#process-btn").on("click", function () {
       console.log("Raw data from backend:", data);
       step2Results = data;
       renderResultsTable(data);
+      localStorage.setItem("saved_results", JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
@@ -82,7 +83,7 @@ $("#process-btn").on("click", function () {
   });
 });
 
-$("#process-single-btn").on("click", function () {
+  $("#process-single-btn").on("click", function () {
   var prompt = $("#prompt").val();
   var instructions = $("#instructions").val();
   var rowIndex = parseInt($("#row-index").val()) || 0;
@@ -98,14 +99,15 @@ $("#process-single-btn").on("click", function () {
     success: function (data) {
       step2Results[rowIndex] = data;
       addOrUpdateResultRow(data, rowIndex);
+      localStorage.setItem("saved_results", JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
     },
   });
-});
+  });
 
-$(document).ready(function () {
+  $(document).ready(function () {
   var defaultInstructions = `You are a contact generation expert for sales.
 
 For the business provided, find all key contacts. Prioritize:  
@@ -138,6 +140,15 @@ Example output:
   { "firstname": "Carlos", "lastname": "Rivera", "role": "COO", "email": "carlos.rivera@abccompany.com" }
 ]`;
   $("#instructions").val(defaultInstructions);
+  var savedPrompt = localStorage.getItem("generate_contacts_step2_prompt");
+  if (savedPrompt && savedPrompt.trim() !== "") {
+    $("#prompt").val(savedPrompt);
+  } else {
+    $("#prompt").val("{Business_Name}");
+  }
+  $("#prompt").on("input", function () {
+    localStorage.setItem("generate_contacts_step2_prompt", $(this).val());
+  });
 
   var saved = localStorage.getItem("saved_results");
   if (saved) {
@@ -150,6 +161,7 @@ Example output:
   }
 });
 
-$("#save-setup-btn").on("click", function () {
+$(window).on("beforeunload", function () {
+  localStorage.setItem("generate_contacts_step2_prompt", $("#prompt").val());
   localStorage.setItem("saved_results", JSON.stringify(step2Results));
 });


### PR DESCRIPTION
## Summary
- Auto-save Step 1 TSV data and related fields and restore on page unload
- Persist Step 2 prompts and results with sensible defaults
- Reduce prompt textarea height for easier editing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896961e3c708333bcbfbc74b2b28d28