### PR TITLE
Increase timeouts and allow longer processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ ENV PYTHONUNBUFFERED=1
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["python", "app.py"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "300", "app:create_app()"]

--- a/frontend/js/parse_locations/step4.js
+++ b/frontend/js/parse_locations/step4.js
@@ -55,7 +55,6 @@ async function processRecursive() {
         return;
     }
 
-    const startTime = Date.now();
     const queue = [];
 
     initialRows.forEach(function (row) {
@@ -68,11 +67,6 @@ async function processRecursive() {
     });
 
     while (queue.length > 0) {
-        if (Date.now() - startTime > 60000) {
-            alert('Process reached the 4 min timeout limit.');
-            return;
-        }
-
         const row = queue.shift();
         removeRowFromTable(row);
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,10 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
     }
 }

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -22,6 +22,10 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
         }
 
         error_log /var/log/nginx/error.log notice;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ flask
 pandas
 openai
 python-dotenv
+gunicorn
 


### PR DESCRIPTION
## Summary
- allow long-running backend calls by using gunicorn with a 300s timeout
- extend nginx configs with 300s proxy timeouts
- remove 60s front-end cap so recursive location processing can finish

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `nginx -t -c /workspace/sfa-lead-generator/nginx/nginx.conf` *(fails: host not found in upstream "backend:5000")*


------
https://chatgpt.com/codex/tasks/task_e_68974e2c82388333a1388f345d21e8ce