### PR TITLE
Add range processing and index display for find businesses

### DIFF
--- a/backend/find_businesses/processing.py
+++ b/backend/find_businesses/processing.py
@@ -64,10 +64,10 @@ def parse_results_to_businesses(results):
 def apply_prompt_to_dataframe(df: pd.DataFrame, instructions: str, prompt: str):
     """Apply the prompt to each row of the dataframe and return results."""
     processed = []
-    for _, row in df.iterrows():
+    for idx, row in df.iterrows():
         message = _format_prompt(prompt, row)
         result = call_openai(instructions, message)
-        processed.append({**row.to_dict(), "result": result})
+        processed.append({"index": int(idx), **row.to_dict(), "result": result})
     return processed
 
 

--- a/backend/find_businesses/step2.py
+++ b/backend/find_businesses/step2.py
@@ -34,4 +34,26 @@ def process_single():
     result = apply_prompt_to_row(row, instructions, prompt)
     new_row = row.to_dict()
     new_row["result"] = result
+    new_row["index"] = row_index
     return jsonify(new_row)
+
+
+@step2_bp.route("/find_businesses/process_range", methods=["POST"])
+def process_range():
+    """Process a range of rows from start_index to end_index inclusive."""
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    start_index = int(request.json.get("start_index", 0))
+    end_index = int(request.json.get("end_index", start_index))
+
+    if (
+        data_store.DATAFRAME is None
+        or start_index < 0
+        or end_index >= len(data_store.DATAFRAME)
+        or start_index > end_index
+    ):
+        return "Invalid index range", 400
+
+    df_slice = data_store.DATAFRAME.iloc[start_index : end_index + 1]
+    results = apply_prompt_to_dataframe(df_slice, instructions, prompt)
+    return jsonify(results)

--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -40,8 +40,10 @@
         <textarea id="instructions" style="height:80px;"></textarea><br>
         <label>Prompt (use column names in {braces}):</label><br>
           <textarea id="prompt" style="height:100px;"></textarea><br>
-        <label>Row index for single run:</label>
-        <input type="number" id="row-index" value="0" min="0"><br>
+        <label>Row indices:</label>
+        <input type="number" id="start-index" value="0" min="0">
+        <input type="number" id="end-index" value="0" min="0"><br>
+        <button id="process-range-btn">Process Range</button>
         <button id="process-single-btn">Process Single Row</button>
         <button id="process-btn">Process All Rows</button>
         <button type="button" id="clear-step2">Clear Step 2</button>

--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -85,13 +85,13 @@ function renderDataTable(data) {
     $("#table-container").html("No rows");
     return;
   }
-  var html = "<table><thead><tr>";
+  var html = "<table><thead><tr><th>index</th>";
   Object.keys(data[0]).forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
   html += "</tr></thead><tbody>";
-  data.forEach(function (row) {
-    html += "<tr>";
+  data.forEach(function (row, idx) {
+    html += "<tr><td>" + idx + "</td>";
     Object.values(row).forEach(function (val) {
       html += "<td>" + val + "</td>";
     });


### PR DESCRIPTION
## Summary
- allow applying prompts to a range of rows with `/find_businesses/process_range`
- include row index in Step1 and Step2 tables to map results back to original data
- add start and end index controls on Find Businesses step 2 page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689794c90984833388f5195a5540ebe4