### PR TITLE
Show raw output and stop execution on Find Businesses page

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -45,9 +45,10 @@
         <input type="number" id="end-index" value="0" min="0"><br>
         <button id="process-range-btn">Process Range</button>
         <button id="process-single-btn">Process Single Row</button>
-        <button id="process-btn">Process All Rows</button>
+        <button id="stop-execution-btn">Stop Execution</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
+    <pre id="raw-output" style="margin-top:1em; white-space: pre-wrap;"></pre>
     <div id="results-container" style="margin-top:1em;"></div>
 </div>
 


### PR DESCRIPTION
## Summary
- Display raw API responses below Step 2 for single and range processing
- Remove "Process All Rows" and add a cancellable "Stop Execution" button
- Allow aborting in-progress requests to cancel API queries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689798dca8f4833392c76b411ad0ad4c