### PR TITLE
Extend request timeouts and make find-business results scrollable

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -48,8 +48,8 @@
         <button id="stop-execution-btn">Stop Execution</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
-    <pre id="raw-output" style="margin-top:1em; white-space: pre-wrap;"></pre>
-    <div id="results-container" style="margin-top:1em;"></div>
+    <pre id="raw-output" style="margin-top:1em; white-space: pre-wrap; max-height:300px; overflow-y:auto;"></pre>
+    <div id="results-container" style="margin-top:1em; max-height:300px; overflow-y:auto;"></div>
 </div>
 
  <div id="step3" style="margin-top:2em;">

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,10 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 300;
+            proxy_send_timeout    300;
+            proxy_read_timeout    300;
+            send_timeout          300;
         }
     }
 }

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -22,6 +22,10 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 300;
+            proxy_send_timeout    300;
+            proxy_read_timeout    300;
+            send_timeout          300;
         }
 
         error_log /var/log/nginx/error.log notice;


### PR DESCRIPTION
## Summary
- extend Nginx proxy timeouts to 300s to handle long-running range processing requests
- add scrollable containers for raw output and results on the Find Businesses page when content grows large

## Testing
- `pytest` (no tests ran)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979e169b3883339d1519532114fdee