### PR TITLE
Ensure scrollable outputs exceed 300px

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -8,6 +8,10 @@
         table { border-collapse: collapse; margin-top: 1em; }
         th, td { border: 1px solid #ccc; padding: 4px; }
         textarea { width: 100%; height: 150px; }
+        .scrollable-output {
+            max-height: 300px;
+            overflow-y: auto;
+        }
     </style>
 </head>
 <body>
@@ -30,7 +34,7 @@
     </form>
 
 
-    <div id="table-container"></div>
+    <div id="table-container" class="scrollable-output"></div>
 </div>
 
  <div id="step2" style="margin-top:2em;">
@@ -46,14 +50,14 @@
         <button id="process-btn">Process All Rows</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
-    <div id="results-container" style="margin-top:1em;"></div>
+    <div id="results-container" class="scrollable-output" style="margin-top:1em;"></div>
 </div>
 
  <div id="step3" style="margin-top:2em;">
      <h2>STEP 3: Parse Businesses</h2>
     <button id="parse-btn">Parse Step 2 Results</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
-    <div id="contacts-container" style="margin-top:1em;"></div>
+    <div id="contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
  </div>
 
  <script src="{{ url_for('static', filename='find_businesses/step1.js') }}"></script>

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -8,6 +8,10 @@
         table { border-collapse: collapse; margin-top: 1em; }
         th, td { border: 1px solid #ccc; padding: 4px; }
         textarea { width: 100%; height: 150px; }
+        .scrollable-output {
+            max-height: 300px;
+            overflow-y: auto;
+        }
     </style>
 </head>
 <body>
@@ -30,7 +34,7 @@
     </form>
 
 
-    <div id="table-container"></div>
+    <div id="table-container" class="scrollable-output"></div>
 </div>
 
 <div id="step2" style="margin-top:2em;">
@@ -46,14 +50,14 @@
         <button id="process-btn">Process All Rows</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
-    <div id="results-container" style="margin-top:1em;"></div>
+    <div id="results-container" class="scrollable-output" style="margin-top:1em;"></div>
 </div>
 
 <div id="step3" style="margin-top:2em;">
     <h2>STEP 3: Parse Contacts</h2>
     <button id="parse-btn">Parse Step 2 Results</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
-    <div id="contacts-container" style="margin-top:1em;"></div>
+    <div id="contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
 </div>
 
 <script src="{{ url_for('static', filename='generate_contacts/step1.js') }}"></script>

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -3,6 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <title>SFA Lead Generator</title>
+    <style>
+        .scrollable-output {
+            max-height: 300px;
+            overflow-y: auto;
+        }
+    </style>
 </head>
 <body>
 <h1>SFA Lead Generator</h1>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <title>Parse Locations</title>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <style>
+        .scrollable-output {
+            max-height: 300px;
+            overflow-y: auto;
+        }
+    </style>
 </head>
 <body>
 <h1>Parse Locations</h1>
@@ -26,7 +32,7 @@
         <button type="button" id="clear-step1">Clear Step 1</button>
     </form>
 
-    <div id="step1-results-container"></div>
+    <div id="step1-results-container" class="scrollable-output"></div>
 </div>
 
 <div id="step2">
@@ -38,7 +44,7 @@
     <button type="button" id="save-step2">Save Step 2</button>
     <button type="button" id="clear-step2">Clear Step 2</button>
 
-    <div id="step2-results-container"></div>
+    <div id="step2-results-container" class="scrollable-output"></div>
 </div>
 
 <div id="step3">
@@ -46,7 +52,7 @@
     <button id="parse-data">Parse Data</button>
     <button type="button" id="save-step3">Save Step 3</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
-    <div id="step3-results-container"></div>
+    <div id="step3-results-container" class="scrollable-output"></div>
 </div>
 
 <div id="step4">
@@ -55,7 +61,7 @@
     <input type="number" id="population-stop-depth" value="100000"><br><br>
     <button id="process-recursive">PROCESS ALL</button>
     <button type="button" id="clear-step4">Clear Step 4</button>
-    <div id="step4-results-container"></div>
+    <div id="step4-results-container" class="scrollable-output"></div>
 </div>
 
 <script src="{{ url_for('static', filename='parse_locations/step1.js') }}"></script>


### PR DESCRIPTION
## Summary
- Add `.scrollable-output` CSS class limiting output areas to 300px with vertical scrolling
- Apply scrollable styling to result containers on Parse Locations, Find Businesses, and Generate Contacts pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ae774d648333a070c1a4b24242e0