### PR TITLE
feat: process row ranges for business search

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -42,11 +42,17 @@
           <textarea id="prompt" style="height:100px;"></textarea><br>
         <label>Row index for single run:</label>
         <input type="number" id="row-index" value="0" min="0"><br>
-        <button id="process-single-btn">Process Single Row</button>
-        <button id="process-btn">Process All Rows</button>
+        <button id="process-single-btn">Process Single Row</button><br>
+        <label>Start index:</label>
+        <input type="number" id="start-index" value="0" min="0">
+        <label>End index:</label>
+        <input type="number" id="end-index" value="0" min="0"><br>
+        <button id="process-range-btn">Process Range</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
     <div id="results-container" style="margin-top:1em;"></div>
+    <h3>Raw Output</h3>
+    <div id="raw-output" style="white-space:pre-wrap;"></div>
 </div>
 
  <div id="step3" style="margin-top:2em;">

--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -85,13 +85,13 @@ function renderDataTable(data) {
     $("#table-container").html("No rows");
     return;
   }
-  var html = "<table><thead><tr>";
+  var html = "<table><thead><tr><th>index</th>";
   Object.keys(data[0]).forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
   html += "</tr></thead><tbody>";
-  data.forEach(function (row) {
-    html += "<tr>";
+  data.forEach(function (row, idx) {
+    html += "<tr><td>" + idx + "</td>";
     Object.values(row).forEach(function (val) {
       html += "<td>" + val + "</td>";
     });

--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -40,15 +40,22 @@ function renderBusinessesTable(data) {
 }
 
 $("#parse-btn").on("click", function () {
-  if (!step2Results.length) {
+  if (!Object.keys(step2Results).length) {
     alert("No Step 2 results to parse");
     return;
   }
+  var resultsArray = Object.keys(step2Results)
+    .sort(function (a, b) {
+      return a - b;
+    })
+    .map(function (k) {
+      return step2Results[k];
+    });
   $.ajax({
     url: "/find_businesses/parse_contacts",
     method: "POST",
     contentType: "application/json",
-    data: JSON.stringify({ results: step2Results }),
+    data: JSON.stringify({ results: resultsArray }),
     success: function (data) {
       parsedBusinesses = parsedBusinesses.concat(data);
       renderBusinessesTable(parsedBusinesses);


### PR DESCRIPTION
## Summary
- add index column to initial data table
- support processing a range of rows sequentially with persistent raw output
- adapt step3 parsing to new results structure

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b153d9f88333af79d64ea5515852