### PR TITLE
Add range processing to Find Businesses step 2

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -46,11 +46,19 @@
           <textarea id="prompt" style="height:100px;"></textarea><br>
         <label>Row index for single run:</label>
         <input type="number" id="row-index" value="0" min="0"><br>
+        <label>Start index:</label>
+        <input type="number" id="start-index" value="0" min="0">
+        <label>End index:</label>
+        <input type="number" id="end-index" value="0" min="0"><br>
         <button id="process-single-btn">Process Single Row</button>
-        <button id="process-btn">Process All Rows</button>
+        <button id="process-range-btn">Process Range</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
     <div id="results-container" class="scrollable-output" style="margin-top:1em;"></div>
+    <div id="raw-output-section" style="margin-top:1em;">
+        <h3>Raw Output</h3>
+        <div id="raw-output-container" class="scrollable-output"></div>
+    </div>
 </div>
 
  <div id="step3" style="margin-top:2em;">

--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -85,13 +85,13 @@ function renderDataTable(data) {
     $("#table-container").html("No rows");
     return;
   }
-  var html = "<table><thead><tr>";
+  var html = "<table><thead><tr><th>index</th>";
   Object.keys(data[0]).forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
   html += "</tr></thead><tbody>";
-  data.forEach(function (row) {
-    html += "<tr>";
+  data.forEach(function (row, idx) {
+    html += "<tr><td>" + idx + "</td>";
     Object.values(row).forEach(function (val) {
       html += "<td>" + val + "</td>";
     });

--- a/frontend/js/find_businesses/step2.js
+++ b/frontend/js/find_businesses/step2.js
@@ -1,4 +1,4 @@
-var step2Results = [];
+var step2Results = {};
 
 function getBusinessNameKey(obj) {
   for (var key in obj) {
@@ -15,81 +15,114 @@ function getBusinessNameKey(obj) {
   return Object.keys(obj)[0];
 }
 
-function renderResultsTable(data) {
-  if (!data.length) {
+function renderResultsTable(resultsObj) {
+  var indexes = Object.keys(resultsObj).sort(function (a, b) {
+    return parseInt(a) - parseInt(b);
+  });
+  if (!indexes.length) {
     $("#results-container").html("No results");
     return;
   }
-  var businessKey = getBusinessNameKey(data[0]);
+  var firstRow = resultsObj[indexes[0]];
+  var businessKey = getBusinessNameKey(firstRow);
   var html =
-    "<table><thead><tr>" +
-    "<th>" +
+    "<table><thead><tr><th>index</th><th>" +
     businessKey +
-    "</th><th>result</th>" +
-    "</tr></thead><tbody>";
-  data.forEach(function (row) {
+    "</th><th>result</th></tr></thead><tbody>";
+  indexes.forEach(function (idx) {
+    var row = resultsObj[idx];
     html +=
-      "<tr>" +
-      "<td>" +
+      "<tr><td>" +
+      idx +
+      "</td><td>" +
       (row[businessKey] || "") +
-      "</td>" +
-      "<td>" +
+      "</td><td>" +
       row.result +
-      "</td>" +
-      "</tr>";
+      "</td></tr>";
   });
   html += "</tbody></table>";
   $("#results-container").html(html);
 }
 
-function addOrUpdateResultRow(rowData, index) {
-  var $table = $("#results-container table");
-  if (!$table.length) {
-    renderResultsTable([rowData]);
-    return;
-  }
-  var businessKey = getBusinessNameKey(rowData);
-  var rowHtml =
-    "<tr><td>" +
-    (rowData[businessKey] || "") +
-    "</td><td>" +
-    rowData.result +
-    "</td></tr>";
-  var $rows = $table.find("tbody tr");
-  if (index < $rows.length) {
-    $rows.eq(index).replaceWith(rowHtml);
+function updateRawOutput(rowIndex, data) {
+  var container = $("#raw-output-container");
+  var entryId = "raw-row-" + rowIndex;
+  var $entry = $("#" + entryId);
+  var pre = $("<pre></pre>").text(JSON.stringify(data, null, 2));
+  if ($entry.length) {
+    $entry.find("pre").replaceWith(pre);
   } else {
-    $table.find("tbody").append(rowHtml);
+    var wrapper = $("<div></div>")
+      .attr("id", entryId)
+      .append("<h4>Row " + rowIndex + "</h4>")
+      .append(pre);
+    container.append(wrapper);
   }
 }
 
-  $("#process-btn").on("click", function () {
-    var prompt = $("#prompt").val();
-    var instructions = $("#instructions").val();
-    $.ajax({
-      url: "/find_businesses/process",
-      method: "POST",
-    contentType: "application/json",
-    data: JSON.stringify({ prompt: prompt, instructions: instructions }),
-    success: function (data) {
-      console.log("Raw data from backend:", data);
-      step2Results = data;
-      renderResultsTable(data);
-      localStorage.setItem("saved_results", JSON.stringify(step2Results));
-    },
-    error: function (xhr) {
-      alert(xhr.responseText);
-    },
-  });
+$("#process-range-btn").on("click", function () {
+  var prompt = $("#prompt").val();
+  var instructions = $("#instructions").val();
+  var start = parseInt($("#start-index").val()) || 0;
+  var end = parseInt($("#end-index").val()) || 0;
+  if (end < start) {
+    alert("End index must be greater than or equal to start index");
+    return;
+  }
+  var indexes = [];
+  for (var i = start; i <= end; i++) {
+    indexes.push(i);
+  }
+
+  function processNext(pos) {
+    if (pos >= indexes.length) return;
+    var idx = indexes[pos];
+    function send(attempt) {
+      $.ajax({
+        url: "/find_businesses/process_single",
+        method: "POST",
+        contentType: "application/json",
+        data: JSON.stringify({
+          prompt: prompt,
+          instructions: instructions,
+          row_index: idx,
+        }),
+        success: function (data) {
+          data.index = idx;
+          step2Results[idx] = data;
+          renderResultsTable(step2Results);
+          updateRawOutput(idx, data);
+          localStorage.setItem("saved_results", JSON.stringify(step2Results));
+          setTimeout(function () {
+            processNext(pos + 1);
+          }, 300);
+        },
+        error: function (xhr) {
+          console.error("Error processing row", idx, xhr.responseText);
+          if (attempt < 1) {
+            setTimeout(function () {
+              send(attempt + 1);
+            }, 300);
+          } else {
+            setTimeout(function () {
+              processNext(pos + 1);
+            }, 300);
+          }
+        },
+      });
+    }
+    send(0);
+  }
+  processNext(0);
 });
 
-  $("#process-single-btn").on("click", function () {
-    var prompt = $("#prompt").val();
-    var instructions = $("#instructions").val();
-    var rowIndex = parseInt($("#row-index").val()) || 0;
-    $.ajax({
-      url: "/find_businesses/process_single",
-      method: "POST",
+$("#process-single-btn").on("click", function () {
+  var prompt = $("#prompt").val();
+  var instructions = $("#instructions").val();
+  var rowIndex = parseInt($("#row-index").val()) || 0;
+  $.ajax({
+    url: "/find_businesses/process_single",
+    method: "POST",
     contentType: "application/json",
     data: JSON.stringify({
       prompt: prompt,
@@ -97,15 +130,17 @@ function addOrUpdateResultRow(rowData, index) {
       row_index: rowIndex,
     }),
     success: function (data) {
+      data.index = rowIndex;
       step2Results[rowIndex] = data;
-      addOrUpdateResultRow(data, rowIndex);
+      renderResultsTable(step2Results);
+      updateRawOutput(rowIndex, data);
       localStorage.setItem("saved_results", JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
     },
   });
-  });
+});
 
 $(document).ready(function () {
   var defaultInstructions = `You are a business finder expert for sales.
@@ -136,14 +171,18 @@ DO NOT return any explanation, description, or formatting outside the JSON.`;
     try {
       step2Results = JSON.parse(saved);
       renderResultsTable(step2Results);
+      Object.keys(step2Results).forEach(function (idx) {
+        updateRawOutput(idx, step2Results[idx]);
+      });
     } catch (e) {
       console.error(e);
     }
   }
 
   $("#clear-step2").on("click", function () {
-    step2Results = [];
+    step2Results = {};
     $("#results-container").empty();
+    $("#raw-output-container").empty();
     $("#prompt").val(defaultPrompt);
     $("#instructions").val(defaultInstructions);
     localStorage.removeItem("saved_results");

--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -40,7 +40,7 @@ function renderBusinessesTable(data) {
 }
 
 $("#parse-btn").on("click", function () {
-  if (!step2Results.length) {
+  if (Object.keys(step2Results).length === 0) {
     alert("No Step 2 results to parse");
     return;
   }
@@ -48,7 +48,7 @@ $("#parse-btn").on("click", function () {
     url: "/find_businesses/parse_contacts",
     method: "POST",
     contentType: "application/json",
-    data: JSON.stringify({ results: step2Results }),
+    data: JSON.stringify({ results: Object.values(step2Results) }),
     success: function (data) {
       parsedBusinesses = parsedBusinesses.concat(data);
       renderBusinessesTable(parsedBusinesses);


### PR DESCRIPTION
## Summary
- replace "Process All" with range processing and start/end index inputs
- sequentially process selected rows and show raw JSON outputs per row
- show row indexes in step1 data table and step2 results

## Testing
- `python -m py_compile backend/find_businesses/step1.py backend/find_businesses/step2.py backend/find_businesses/step3.py backend/find_businesses/processing.py`
- `node --check frontend/js/find_businesses/step1.js frontend/js/find_businesses/step2.js frontend/js/find_businesses/step3.js`

------
https://chatgpt.com/codex/tasks/task_e_6897b3c21d888333ac56efd47ce44b3d