### PR TITLE
Enable range processing for contact generation

### DIFF
--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -46,8 +46,12 @@
           <textarea id="prompt" style="height:100px;"></textarea><br>
         <label>Row index for single run:</label>
         <input type="number" id="row-index" value="0" min="0"><br>
+        <label>Start index:</label>
+        <input type="number" id="start-index" value="0" min="0">
+        <label>End index:</label>
+        <input type="number" id="end-index" value="0" min="0"><br>
         <button id="process-single-btn">Process Single Row</button>
-        <button id="process-btn">Process All Rows</button>
+        <button id="process-range-btn">Process Range</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
     <div id="results-container" class="scrollable-output" style="margin-top:1em;"></div>

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -1,4 +1,4 @@
-var step2Results = [];
+var step2Results = {};
 
 function getBusinessNameKey(obj) {
   for (var key in obj) {
@@ -15,75 +15,91 @@ function getBusinessNameKey(obj) {
   return Object.keys(obj)[0];
 }
 
-function renderResultsTable(data) {
-  if (!data.length) {
+function renderResultsTable(resultsObj) {
+  var indexes = Object.keys(resultsObj).sort(function (a, b) {
+    return parseInt(a) - parseInt(b);
+  });
+  if (!indexes.length) {
     $("#results-container").html("No results");
     return;
   }
-  var businessKey = getBusinessNameKey(data[0]);
+  var firstRow = resultsObj[indexes[0]];
+  var businessKey = getBusinessNameKey(firstRow);
   var html =
-    "<table><thead><tr>" +
-    "<th>" +
+    "<table><thead><tr><th>index</th><th>" +
     businessKey +
-    "</th><th>result</th>" +
-    "</tr></thead><tbody>";
-  data.forEach(function (row) {
+    "</th><th>result</th></tr></thead><tbody>";
+  indexes.forEach(function (idx) {
+    var row = resultsObj[idx];
     html +=
-      "<tr>" +
-      "<td>" +
+      "<tr><td>" +
+      idx +
+      "</td><td>" +
       (row[businessKey] || "") +
-      "</td>" +
-      "<td>" +
+      "</td><td>" +
       row.result +
-      "</td>" +
-      "</tr>";
+      "</td></tr>";
   });
   html += "</tbody></table>";
   $("#results-container").html(html);
 }
 
-function addOrUpdateResultRow(rowData, index) {
-  var $table = $("#results-container table");
-  if (!$table.length) {
-    renderResultsTable([rowData]);
-    return;
-  }
-  var businessKey = getBusinessNameKey(rowData);
-  var rowHtml =
-    "<tr><td>" +
-    (rowData[businessKey] || "") +
-    "</td><td>" +
-    rowData.result +
-    "</td></tr>";
-  var $rows = $table.find("tbody tr");
-  if (index < $rows.length) {
-    $rows.eq(index).replaceWith(rowHtml);
-  } else {
-    $table.find("tbody").append(rowHtml);
-  }
-}
-
-$("#process-btn").on("click", function () {
+$("#process-range-btn").on("click", function () {
   var prompt = $("#prompt").val();
   var instructions = $("#instructions").val();
-  $.ajax({
-    url: "/process",
-    method: "POST",
-    contentType: "application/json",
-    data: JSON.stringify({ prompt: prompt, instructions: instructions }),
-    success: function (data) {
-      console.log("Raw data from backend:", data);
-      step2Results = data;
-      renderResultsTable(data);
-      localStorage.setItem("saved_results", JSON.stringify(step2Results));
-    },
-    error: function (xhr) {
-      alert(xhr.responseText);
-    },
-  });
+  var start = parseInt($("#start-index").val()) || 0;
+  var end = parseInt($("#end-index").val()) || 0;
+  if (end < start) {
+    alert("End index must be greater than or equal to start index");
+    return;
+  }
+  var indexes = [];
+  for (var i = start; i <= end; i++) {
+    indexes.push(i);
+  }
+
+  function processNext(pos) {
+    if (pos >= indexes.length) return;
+    var idx = indexes[pos];
+    function send(attempt) {
+      $.ajax({
+        url: "/process_single",
+        method: "POST",
+        contentType: "application/json",
+        data: JSON.stringify({
+          prompt: prompt,
+          instructions: instructions,
+          row_index: idx,
+        }),
+        success: function (data) {
+          data.index = idx;
+          step2Results[idx] = data;
+          renderResultsTable(step2Results);
+          localStorage.setItem("saved_results", JSON.stringify(step2Results));
+          setTimeout(function () {
+            processNext(pos + 1);
+          }, 300);
+        },
+        error: function (xhr) {
+          console.error("Error processing row", idx, xhr.responseText);
+          if (attempt < 1) {
+            setTimeout(function () {
+              send(attempt + 1);
+            }, 300);
+          } else {
+            setTimeout(function () {
+              processNext(pos + 1);
+            }, 300);
+          }
+        },
+      });
+    }
+    send(0);
+  }
+  processNext(0);
 });
 
-  $("#process-single-btn").on("click", function () {
+$("#process-single-btn").on("click", function () {
   var prompt = $("#prompt").val();
   var instructions = $("#instructions").val();
   var rowIndex = parseInt($("#row-index").val()) || 0;
@@ -97,37 +113,38 @@ $("#process-btn").on("click", function () {
       row_index: rowIndex,
     }),
     success: function (data) {
+      data.index = rowIndex;
       step2Results[rowIndex] = data;
-      addOrUpdateResultRow(data, rowIndex);
+      renderResultsTable(step2Results);
       localStorage.setItem("saved_results", JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
     },
   });
-  });
+});
 
-  $(document).ready(function () {
+$(document).ready(function () {
   var defaultInstructions = `You are a contact generation expert for sales.
 
-For the business provided, find all key contacts. Prioritize:  
-– Founders  
-– COOs  
-– Heads of Operations  
-– Other senior decision-makers  
+For the business provided, find all key contacts. Prioritize:
+– Founders
+– COOs
+– Heads of Operations
+– Other senior decision-makers
 
-Required output format:  
-Return results as a JSON array of objects.  
-Each object must contain:  
-- firstname  
-- lastname  
+Required output format:
+Return results as a JSON array of objects.
+Each object must contain:
+- firstname
+- lastname
 - role
 - email (if you can't find their email directly guess it)
 
-⚠️ Do not include company name, emails, or any extra explanation.  
+⚠️ Do not include company name, emails, or any extra explanation.
 ⚠️ Output only the raw JSON.
 
-Example input:  
+Example input:
 ABC Company
 
 Example output:
@@ -162,7 +179,7 @@ Example output:
   }
 
   $("#clear-step2").on("click", function () {
-    step2Results = [];
+    step2Results = {};
     $("#results-container").empty();
     $("#prompt").val(defaultPrompt);
     $("#instructions").val(defaultInstructions);
@@ -175,3 +192,4 @@ $(window).on("beforeunload", function () {
   localStorage.setItem("generate_contacts_step2_prompt", $("#prompt").val());
   localStorage.setItem("saved_results", JSON.stringify(step2Results));
 });
+

--- a/frontend/js/generate_contacts/step3.js
+++ b/frontend/js/generate_contacts/step3.js
@@ -40,7 +40,7 @@ function renderContactsTable(data) {
 }
 
 $("#parse-btn").on("click", function () {
-  if (!step2Results.length) {
+  if (Object.keys(step2Results).length === 0) {
     alert("No Step 2 results to parse");
     return;
   }
@@ -48,7 +48,7 @@ $("#parse-btn").on("click", function () {
     url: "/parse_contacts",
     method: "POST",
     contentType: "application/json",
-    data: JSON.stringify({ results: step2Results }),
+    data: JSON.stringify({ results: Object.values(step2Results) }),
     success: function (data) {
       parsedContacts = parsedContacts.concat(data);
       renderContactsTable(parsedContacts);


### PR DESCRIPTION
## Summary
- Add start/end index controls and range processing to Step 2 of the Generate Contacts page
- Persist and render range-processed results with index column
- Adjust Step 3 parsing to handle object-based Step 2 results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897be2009d8833382d99480084d536d