### PR TITLE
Sanitize NaN values before returning step2 rows

### DIFF
--- a/backend/find_businesses/processing.py
+++ b/backend/find_businesses/processing.py
@@ -67,7 +67,8 @@ def apply_prompt_to_dataframe(df: pd.DataFrame, instructions: str, prompt: str):
     for _, row in df.iterrows():
         message = _format_prompt(prompt, row)
         result = call_openai(instructions, message)
-        processed.append({**row.to_dict(), "result": result})
+        row_dict = row.where(pd.notnull(row), None).to_dict()
+        processed.append({**row_dict, "result": result})
     return processed
 
 

--- a/backend/find_businesses/step2.py
+++ b/backend/find_businesses/step2.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+import pandas as pd
 
 from . import data_store
 from .processing import apply_prompt_to_dataframe, apply_prompt_to_row
@@ -32,6 +33,6 @@ def process_single():
 
     row = data_store.DATAFRAME.iloc[row_index]
     result = apply_prompt_to_row(row, instructions, prompt)
-    new_row = row.to_dict()
-    new_row["result"] = result
-    return jsonify(new_row)
+    row_dict = row.where(pd.notnull(row), None).to_dict()
+    row_dict["result"] = result
+    return jsonify(row_dict)

--- a/backend/generate_contacts/processing.py
+++ b/backend/generate_contacts/processing.py
@@ -94,7 +94,8 @@ def apply_prompt_to_dataframe(df: pd.DataFrame, instructions: str, prompt: str):
     for _, row in df.iterrows():
         message = _format_prompt(prompt, row)
         result = call_openai(instructions, message)
-        processed.append({**row.to_dict(), "result": result})
+        row_dict = row.where(pd.notnull(row), None).to_dict()
+        processed.append({**row_dict, "result": result})
     return processed
 
 

--- a/backend/generate_contacts/step2.py
+++ b/backend/generate_contacts/step2.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+import pandas as pd
 
 from . import data_store
 from .processing import apply_prompt_to_dataframe, apply_prompt_to_row
@@ -31,6 +32,6 @@ def process_single():
 
     row = data_store.DATAFRAME.iloc[row_index]
     result = apply_prompt_to_row(row, instructions, prompt)
-    new_row = row.to_dict()
-    new_row["result"] = result
-    return jsonify(new_row)
+    row_dict = row.where(pd.notnull(row), None).to_dict()
+    row_dict["result"] = result
+    return jsonify(row_dict)


### PR DESCRIPTION
## Summary
- Replace raw `row.to_dict()` calls with null-safe conversions in step2 endpoints
- Ensure dataframe processing functions convert NaNs to `None` before JSON serialisation
- Apply the same NaN sanitisation to `find_businesses` endpoints

## Testing
- `pytest`
- Manual Flask test client calls to `/process_single`, `/process`, `/find_businesses/process_single`, `/find_businesses/process`

------
https://chatgpt.com/codex/tasks/task_e_68a64ef6a0948333a92a103de0a54368