### PR TITLE
Align generate contacts step2 routes with find businesses

### DIFF
--- a/backend/generate_contacts/step2.py
+++ b/backend/generate_contacts/step2.py
@@ -3,10 +3,11 @@ from flask import Blueprint, jsonify, request
 from . import data_store
 from .processing import apply_prompt_to_dataframe, apply_prompt_to_row
 
-step2_bp = Blueprint("step2", __name__)
+# Blueprint for Step 2 of Generate Contacts
+step2_bp = Blueprint("generate_contacts_step2", __name__)
 
 
-@step2_bp.route("/process", methods=["POST"])
+@step2_bp.route("/generate_contacts/process", methods=["POST"])
 def process():
     """Apply the prompt to the entire DataFrame."""
     prompt = request.json.get("prompt", "")
@@ -15,7 +16,7 @@ def process():
     return jsonify(results)
 
 
-@step2_bp.route("/process_single", methods=["POST"])
+@step2_bp.route("/generate_contacts/process_single", methods=["POST"])
 def process_single():
     """Process a single row of data."""
     prompt = request.json.get("prompt", "")

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -63,7 +63,7 @@ $("#process-range-btn").on("click", function () {
     var idx = indexes[pos];
     function send(attempt) {
       $.ajax({
-        url: "/process_single",
+        url: "/generate_contacts/process_single",
         method: "POST",
         contentType: "application/json",
         data: JSON.stringify({
@@ -104,7 +104,7 @@ $("#process-single-btn").on("click", function () {
   var instructions = $("#instructions").val();
   var rowIndex = parseInt($("#row-index").val()) || 0;
   $.ajax({
-    url: "/process_single",
+    url: "/generate_contacts/process_single",
     method: "POST",
     contentType: "application/json",
     data: JSON.stringify({


### PR DESCRIPTION
## Summary
- Prefix generate contacts step2 backend routes with `/generate_contacts`
- Update frontend step2 AJAX calls to use `/generate_contacts/process_single`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6507374748333857ec3a5e9685142