### PR TITLE
Fix display of single-row processing results

### DIFF
--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -50,8 +50,8 @@
         <input type="number" id="start-index" value="0" min="0">
         <label>End index:</label>
         <input type="number" id="end-index" value="0" min="0"><br>
-        <button id="process-single-btn">Process Single Row</button>
-        <button id="process-range-btn">Process Range</button>
+        <button type="button" id="process-single-btn">Process Single Row</button>
+        <button type="button" id="process-range-btn">Process Range</button>
         <button type="button" id="clear-step2">Clear Step 2</button>
     </div>
     <div id="results-container" class="scrollable-output" style="margin-top:1em;"></div>

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -44,7 +44,8 @@ function renderResultsTable(resultsObj) {
   $("#results-container").html(html);
 }
 
-$("#process-range-btn").on("click", function () {
+$("#process-range-btn").on("click", function (e) {
+  e.preventDefault();
   var prompt = $("#prompt").val();
   var instructions = $("#instructions").val();
   var start = parseInt($("#start-index").val()) || 0;
@@ -72,6 +73,7 @@ $("#process-range-btn").on("click", function () {
           row_index: idx,
         }),
         success: function (data) {
+          data = typeof data === "string" ? JSON.parse(data) : data;
           data.index = idx;
           step2Results[idx] = data;
           renderResultsTable(step2Results);
@@ -99,7 +101,8 @@ $("#process-range-btn").on("click", function () {
   processNext(0);
 });
 
-$("#process-single-btn").on("click", function () {
+$("#process-single-btn").on("click", function (e) {
+  e.preventDefault();
   var prompt = $("#prompt").val();
   var instructions = $("#instructions").val();
   var rowIndex = parseInt($("#row-index").val()) || 0;
@@ -113,6 +116,7 @@ $("#process-single-btn").on("click", function () {
       row_index: rowIndex,
     }),
     success: function (data) {
+      data = typeof data === "string" ? JSON.parse(data) : data;
       data.index = rowIndex;
       step2Results[rowIndex] = data;
       renderResultsTable(step2Results);


### PR DESCRIPTION
## Summary
- Stop Process Single/Range buttons from submitting forms and show results in-page
- Parse JSON responses and render results table instead of opening a popup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a654169de4833386ff1a52a96ab25b