### PR TITLE
fix: isolate cached step data per page

### DIFF
--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -1,7 +1,14 @@
+const STORAGE_KEYS = {
+  tsv: "find_businesses_step1_tsv",
+  instructions: "find_businesses_step1_instructions",
+  prompt: "find_businesses_step1_prompt",
+};
+
 function loadSavedSetup() {
-  const savedTsv = localStorage.getItem("saved_tsv") || "";
-  const savedInstructions = localStorage.getItem("saved_instructions") || "";
-  const savedPrompt = localStorage.getItem("saved_prompt") || "";
+  const savedTsv = localStorage.getItem(STORAGE_KEYS.tsv) || "";
+  const savedInstructions =
+    localStorage.getItem(STORAGE_KEYS.instructions) || "";
+  const savedPrompt = localStorage.getItem(STORAGE_KEYS.prompt) || "";
 
   return { savedTsv, savedInstructions, savedPrompt };
 }
@@ -45,9 +52,9 @@ function autoPopulateFromSaved() {
 }
 
 function autoSave() {
-  localStorage.setItem("saved_tsv", $("#tsv-input").val());
-  localStorage.setItem("saved_instructions", $("#instructions").val());
-  localStorage.setItem("saved_prompt", $("#prompt").val());
+  localStorage.setItem(STORAGE_KEYS.tsv, $("#tsv-input").val());
+  localStorage.setItem(STORAGE_KEYS.instructions, $("#instructions").val());
+  localStorage.setItem(STORAGE_KEYS.prompt, $("#prompt").val());
 }
 
 $(document).ready(function () {
@@ -76,9 +83,9 @@ $("#upload-form").on("submit", function (e) {
 });
 
 $("#save-setup-btn").on("click", function () {
-  localStorage.setItem("saved_tsv", $("#tsv-input").val());
-  localStorage.setItem("saved_instructions", $("#instructions").val());
-  localStorage.setItem("saved_prompt", $("#prompt").val());
+  localStorage.setItem(STORAGE_KEYS.tsv, $("#tsv-input").val());
+  localStorage.setItem(STORAGE_KEYS.instructions, $("#instructions").val());
+  localStorage.setItem(STORAGE_KEYS.prompt, $("#prompt").val());
 });
 
 $("#clear-step1").on("click", function () {
@@ -86,9 +93,9 @@ $("#clear-step1").on("click", function () {
   $("#instructions").val("");
   $("#prompt").val("");
   $("#table-container").empty();
-  localStorage.removeItem("saved_tsv");
-  localStorage.removeItem("saved_instructions");
-  localStorage.removeItem("saved_prompt");
+  localStorage.removeItem(STORAGE_KEYS.tsv);
+  localStorage.removeItem(STORAGE_KEYS.instructions);
+  localStorage.removeItem(STORAGE_KEYS.prompt);
 });
 
 function renderDataTable(data) {

--- a/frontend/js/find_businesses/step2.js
+++ b/frontend/js/find_businesses/step2.js
@@ -1,3 +1,4 @@
+const RESULTS_KEY = "find_businesses_step2_results";
 var step2Results = {};
 
 function getBusinessNameKey(obj) {
@@ -75,7 +76,7 @@ $("#process-range-btn").on("click", function () {
           data.index = idx;
           step2Results[idx] = data;
           renderResultsTable(step2Results);
-          localStorage.setItem("saved_results", JSON.stringify(step2Results));
+          localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
           setTimeout(function () {
             processNext(pos + 1);
           }, 300);
@@ -116,7 +117,7 @@ $("#process-single-btn").on("click", function () {
       data.index = rowIndex;
       step2Results[rowIndex] = data;
       renderResultsTable(step2Results);
-      localStorage.setItem("saved_results", JSON.stringify(step2Results));
+      localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
     },
     error: function (xhr) {
       alert(xhr.responseText);
@@ -148,7 +149,7 @@ DO NOT return any explanation, description, or formatting outside the JSON.`;
     localStorage.setItem("find_businesses_step2_prompt", $(this).val());
   });
 
-  var saved = localStorage.getItem("saved_results");
+  var saved = localStorage.getItem(RESULTS_KEY);
   if (saved) {
     try {
       step2Results = JSON.parse(saved);
@@ -163,12 +164,12 @@ DO NOT return any explanation, description, or formatting outside the JSON.`;
     $("#results-container").empty();
     $("#prompt").val(defaultPrompt);
     $("#instructions").val(defaultInstructions);
-    localStorage.removeItem("saved_results");
+    localStorage.removeItem(RESULTS_KEY);
     localStorage.removeItem("find_businesses_step2_prompt");
   });
 });
 
 $(window).on("beforeunload", function () {
   localStorage.setItem("find_businesses_step2_prompt", $("#prompt").val());
-  localStorage.setItem("saved_results", JSON.stringify(step2Results));
+  localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
 });

--- a/frontend/js/generate_contacts/step1.js
+++ b/frontend/js/generate_contacts/step1.js
@@ -1,7 +1,14 @@
+const STORAGE_KEYS = {
+  tsv: "generate_contacts_step1_tsv",
+  instructions: "generate_contacts_step1_instructions",
+  prompt: "generate_contacts_step1_prompt",
+};
+
 function loadSavedSetup() {
-  const savedTsv = localStorage.getItem("saved_tsv") || "";
-  const savedInstructions = localStorage.getItem("saved_instructions") || "";
-  const savedPrompt = localStorage.getItem("saved_prompt") || "";
+  const savedTsv = localStorage.getItem(STORAGE_KEYS.tsv) || "";
+  const savedInstructions =
+    localStorage.getItem(STORAGE_KEYS.instructions) || "";
+  const savedPrompt = localStorage.getItem(STORAGE_KEYS.prompt) || "";
 
   return { savedTsv, savedInstructions, savedPrompt };
 }
@@ -40,9 +47,9 @@ function autoPopulateFromSaved() {
 }
 
 function autoSave() {
-  localStorage.setItem("saved_tsv", $("#tsv-input").val());
-  localStorage.setItem("saved_instructions", $("#instructions").val());
-  localStorage.setItem("saved_prompt", $("#prompt").val());
+  localStorage.setItem(STORAGE_KEYS.tsv, $("#tsv-input").val());
+  localStorage.setItem(STORAGE_KEYS.instructions, $("#instructions").val());
+  localStorage.setItem(STORAGE_KEYS.prompt, $("#prompt").val());
 }
 
 $(document).ready(function () {
@@ -71,9 +78,9 @@ $("#upload-form").on("submit", function (e) {
 });
 
 $("#save-setup-btn").on("click", function () {
-  localStorage.setItem("saved_tsv", $("#tsv-input").val());
-  localStorage.setItem("saved_instructions", $("#instructions").val());
-  localStorage.setItem("saved_prompt", $("#prompt").val());
+  localStorage.setItem(STORAGE_KEYS.tsv, $("#tsv-input").val());
+  localStorage.setItem(STORAGE_KEYS.instructions, $("#instructions").val());
+  localStorage.setItem(STORAGE_KEYS.prompt, $("#prompt").val());
 });
 
 $("#clear-step1").on("click", function () {
@@ -81,9 +88,9 @@ $("#clear-step1").on("click", function () {
   $("#instructions").val("");
   $("#prompt").val("");
   $("#table-container").empty();
-  localStorage.removeItem("saved_tsv");
-  localStorage.removeItem("saved_instructions");
-  localStorage.removeItem("saved_prompt");
+  localStorage.removeItem(STORAGE_KEYS.tsv);
+  localStorage.removeItem(STORAGE_KEYS.instructions);
+  localStorage.removeItem(STORAGE_KEYS.prompt);
 });
 
 function renderDataTable(data) {

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -1,3 +1,4 @@
+const RESULTS_KEY = "generate_contacts_step2_results";
 var step2Results = {};
 
 function getBusinessNameKey(obj) {
@@ -75,7 +76,7 @@ $("#process-range-btn").on("click", function () {
           data.index = idx;
           step2Results[idx] = data;
           renderResultsTable(step2Results);
-          localStorage.setItem("saved_results", JSON.stringify(step2Results));
+          localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
           setTimeout(function () {
             processNext(pos + 1);
           }, 300);
@@ -116,7 +117,7 @@ $("#process-single-btn").on("click", function () {
       data.index = rowIndex;
       step2Results[rowIndex] = data;
       renderResultsTable(step2Results);
-      localStorage.setItem("saved_results", JSON.stringify(step2Results));
+      localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
     },
     error: function (xhr) {
       console.error("Error processing row", rowIndex, xhr.responseText);
@@ -168,7 +169,7 @@ Example output:
     localStorage.setItem("generate_contacts_step2_prompt", $(this).val());
   });
 
-  var saved = localStorage.getItem("saved_results");
+  var saved = localStorage.getItem(RESULTS_KEY);
   if (saved) {
     try {
       step2Results = JSON.parse(saved);
@@ -183,13 +184,13 @@ Example output:
     $("#results-container").empty();
     $("#prompt").val(defaultPrompt);
     $("#instructions").val(defaultInstructions);
-    localStorage.removeItem("saved_results");
+    localStorage.removeItem(RESULTS_KEY);
     localStorage.removeItem("generate_contacts_step2_prompt");
   });
 });
 
 $(window).on("beforeunload", function () {
   localStorage.setItem("generate_contacts_step2_prompt", $("#prompt").val());
-  localStorage.setItem("saved_results", JSON.stringify(step2Results));
+  localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
 });
 


### PR DESCRIPTION
## Summary
- avoid cross-page cache collisions by namespacing step1 setup keys
- isolate step2 results cache for each workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a68cb74db48333bfa2dbc51d01b9f4