### PR TITLE
Limit clear step buttons to their outputs

### DIFF
--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -89,13 +89,7 @@ $("#save-setup-btn").on("click", function () {
 });
 
 $("#clear-step1").on("click", function () {
-  $("#tsv-input").val("");
-  $("#instructions").val("");
-  $("#prompt").val("");
   $("#table-container").empty();
-  localStorage.removeItem(STORAGE_KEYS.tsv);
-  localStorage.removeItem(STORAGE_KEYS.instructions);
-  localStorage.removeItem(STORAGE_KEYS.prompt);
 });
 
 function renderDataTable(data) {

--- a/frontend/js/find_businesses/step2.js
+++ b/frontend/js/find_businesses/step2.js
@@ -162,10 +162,7 @@ DO NOT return any explanation, description, or formatting outside the JSON.`;
   $("#clear-step2").on("click", function () {
     step2Results = {};
     $("#results-container").empty();
-    $("#prompt").val(defaultPrompt);
-    $("#instructions").val(defaultInstructions);
     localStorage.removeItem(RESULTS_KEY);
-    localStorage.removeItem("find_businesses_step2_prompt");
   });
 });
 

--- a/frontend/js/generate_contacts/step1.js
+++ b/frontend/js/generate_contacts/step1.js
@@ -84,13 +84,7 @@ $("#save-setup-btn").on("click", function () {
 });
 
 $("#clear-step1").on("click", function () {
-  $("#tsv-input").val("");
-  $("#instructions").val("");
-  $("#prompt").val("");
   $("#table-container").empty();
-  localStorage.removeItem(STORAGE_KEYS.tsv);
-  localStorage.removeItem(STORAGE_KEYS.instructions);
-  localStorage.removeItem(STORAGE_KEYS.prompt);
 });
 
 function renderDataTable(data) {

--- a/frontend/js/generate_contacts/step2.js
+++ b/frontend/js/generate_contacts/step2.js
@@ -182,10 +182,7 @@ Example output:
   $("#clear-step2").on("click", function () {
     step2Results = {};
     $("#results-container").empty();
-    $("#prompt").val(defaultPrompt);
-    $("#instructions").val(defaultInstructions);
     localStorage.removeItem(RESULTS_KEY);
-    localStorage.removeItem("generate_contacts_step2_prompt");
   });
 });
 


### PR DESCRIPTION
## Summary
- Ensure Clear Step 1 only wipes displayed data table for Generate Contacts and Find Businesses
- Restrict Clear Step 2 buttons to removing results without resetting prompts or instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7bcbc0e748333bffbfcff5e8c1418