### PR TITLE
Remove Save Setup buttons

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -29,7 +29,6 @@
         <label>Paste TSV Data:</label><br>
         <textarea name="tsv_text" id="tsv-input"></textarea><br>
         <button type="submit">Load Data</button>
-        <button type="button" id="save-setup-btn">Save Setup</button>
         <button type="button" id="clear-step1">Clear Step 1</button>
     </form>
 

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -29,7 +29,6 @@
         <label>Paste TSV Data:</label><br>
         <textarea name="tsv_text" id="tsv-input"></textarea><br>
         <button type="submit">Load Data</button>
-        <button type="button" id="save-setup-btn">Save Setup</button>
         <button type="button" id="clear-step1">Clear Step 1</button>
     </form>
 

--- a/frontend/js/find_businesses/step1.js
+++ b/frontend/js/find_businesses/step1.js
@@ -82,12 +82,6 @@ $("#upload-form").on("submit", function (e) {
   });
 });
 
-$("#save-setup-btn").on("click", function () {
-  localStorage.setItem(STORAGE_KEYS.tsv, $("#tsv-input").val());
-  localStorage.setItem(STORAGE_KEYS.instructions, $("#instructions").val());
-  localStorage.setItem(STORAGE_KEYS.prompt, $("#prompt").val());
-});
-
 $("#clear-step1").on("click", function () {
   $("#table-container").empty();
 });

--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -60,10 +60,6 @@ $("#parse-btn").on("click", function () {
   });
 });
 
-$("#save-setup-btn").on("click", function () {
-  localStorage.setItem("saved_businesses", JSON.stringify(parsedBusinesses));
-});
-
 $("#clear-step3").on("click", function () {
   $("#contacts-container").empty();
   parsedBusinesses = [];

--- a/frontend/js/generate_contacts/step1.js
+++ b/frontend/js/generate_contacts/step1.js
@@ -77,12 +77,6 @@ $("#upload-form").on("submit", function (e) {
   });
 });
 
-$("#save-setup-btn").on("click", function () {
-  localStorage.setItem(STORAGE_KEYS.tsv, $("#tsv-input").val());
-  localStorage.setItem(STORAGE_KEYS.instructions, $("#instructions").val());
-  localStorage.setItem(STORAGE_KEYS.prompt, $("#prompt").val());
-});
-
 $("#clear-step1").on("click", function () {
   $("#table-container").empty();
 });

--- a/frontend/js/generate_contacts/step3.js
+++ b/frontend/js/generate_contacts/step3.js
@@ -60,10 +60,6 @@ $("#parse-btn").on("click", function () {
   });
 });
 
-$("#save-setup-btn").on("click", function () {
-  localStorage.setItem("saved_contacts", JSON.stringify(parsedContacts));
-});
-
 $("#clear-step3").on("click", function () {
   $("#contacts-container").empty();
   parsedContacts = [];


### PR DESCRIPTION
## Summary
- remove Save Setup buttons from Find Businesses and Generate Contacts pages
- drop unused Save Setup event handlers in related JavaScript files

## Testing
- `pytest` (no tests ran)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a7ca7cc0808333b367f405eda2dcb4