### PR TITLE
Add copy buttons for result tables

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -60,6 +60,7 @@
      <h2>STEP 3: Parse Businesses</h2>
     <button id="parse-btn">Parse Step 2 Results</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
+    <button type="button" id="copy-step3-results">Copy Results</button>
     <div id="contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
  </div>
 

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -60,6 +60,7 @@
     <h2>STEP 3: Parse Contacts</h2>
     <button id="parse-btn">Parse Step 2 Results</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
+    <button type="button" id="copy-step3-results">Copy Results</button>
     <div id="contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
 </div>
 

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -52,6 +52,7 @@
     <button id="parse-data">Parse Data</button>
     <button type="button" id="save-step3">Save Step 3</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
+    <button type="button" id="copy-step3-results">Copy Results</button>
     <div id="step3-results-container" class="scrollable-output"></div>
 </div>
 
@@ -61,6 +62,7 @@
     <input type="number" id="population-stop-depth" value="100000"><br><br>
     <button id="process-recursive">PROCESS ALL</button>
     <button type="button" id="clear-step4">Clear Step 4</button>
+    <button type="button" id="copy-step4-results">Copy Results</button>
     <div id="step4-results-container" class="scrollable-output"></div>
 </div>
 

--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -1,5 +1,23 @@
 var parsedBusinesses = [];
 
+function copyTableToClipboard(selector) {
+  var table = $(selector);
+  if (table.length === 0) {
+    alert('No data to copy.');
+    return;
+  }
+  var rows = [];
+  table.find('tr').each(function () {
+    var cols = [];
+    $(this).find('th,td').each(function () {
+      cols.push($(this).text());
+    });
+    rows.push(cols.join('\t'));
+  });
+  var tsv = rows.join('\n');
+  navigator.clipboard.writeText(tsv);
+}
+
 $(document).ready(function () {
   var saved = localStorage.getItem("saved_businesses");
   if (saved) {
@@ -23,7 +41,7 @@ function renderBusinessesTable(data) {
     if (b === "business_name") return 1;
     return 0;
   });
-  var html = "<table><thead><tr>";
+  var html = '<table id="businesses-results-table"><thead><tr>';
   cols.forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
@@ -64,4 +82,8 @@ $("#clear-step3").on("click", function () {
   $("#contacts-container").empty();
   parsedBusinesses = [];
   localStorage.removeItem("saved_businesses");
+});
+
+$("#copy-step3-results").on("click", function () {
+  copyTableToClipboard('#businesses-results-table');
 });

--- a/frontend/js/generate_contacts/step3.js
+++ b/frontend/js/generate_contacts/step3.js
@@ -1,5 +1,23 @@
 var parsedContacts = [];
 
+function copyTableToClipboard(selector) {
+  var table = $(selector);
+  if (table.length === 0) {
+    alert('No data to copy.');
+    return;
+  }
+  var rows = [];
+  table.find('tr').each(function () {
+    var cols = [];
+    $(this).find('th,td').each(function () {
+      cols.push($(this).text());
+    });
+    rows.push(cols.join('\t'));
+  });
+  var tsv = rows.join('\n');
+  navigator.clipboard.writeText(tsv);
+}
+
 $(document).ready(function () {
   var saved = localStorage.getItem("saved_contacts");
   if (saved) {
@@ -23,7 +41,7 @@ function renderContactsTable(data) {
     if (b === "business_name") return 1;
     return 0;
   });
-  var html = "<table><thead><tr>";
+  var html = '<table id="contacts-results-table"><thead><tr>';
   cols.forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
@@ -64,4 +82,8 @@ $("#clear-step3").on("click", function () {
   $("#contacts-container").empty();
   parsedContacts = [];
   localStorage.removeItem("saved_contacts");
+});
+
+$("#copy-step3-results").on("click", function () {
+  copyTableToClipboard('#contacts-results-table');
 });

--- a/frontend/js/parse_locations/step3.js
+++ b/frontend/js/parse_locations/step3.js
@@ -2,6 +2,24 @@ console.log('step3.js loaded');
 
 let step3Results = [];
 
+function copyTableToClipboard(selector) {
+    const table = $(selector);
+    if (table.length === 0) {
+        alert('No data to copy.');
+        return;
+    }
+    const rows = [];
+    table.find('tr').each(function () {
+        const cols = [];
+        $(this).find('th,td').each(function () {
+            cols.push($(this).text());
+        });
+        rows.push(cols.join('\t'));
+    });
+    const tsv = rows.join('\n');
+    navigator.clipboard.writeText(tsv);
+}
+
 function renderStep3Table(rows, replace = false) {
     let table = $('#step3-results-table');
     if (table.length === 0) {
@@ -76,6 +94,10 @@ $(document).ready(function () {
         $('#step3-results-table').remove();
         step3Results = [];
         localStorage.removeItem('parse_locations_step3');
+    });
+
+    $('#copy-step3-results').on('click', function () {
+        copyTableToClipboard('#step3-results-table');
     });
 });
 

--- a/frontend/js/parse_locations/step4.js
+++ b/frontend/js/parse_locations/step4.js
@@ -2,6 +2,24 @@ console.log('step4.js loaded');
 
 let step4Results = [];
 
+function copyTableToClipboard(selector) {
+    const table = $(selector);
+    if (table.length === 0) {
+        alert('No data to copy.');
+        return;
+    }
+    const rows = [];
+    table.find('tr').each(function () {
+        const cols = [];
+        $(this).find('th,td').each(function () {
+            cols.push($(this).text());
+        });
+        rows.push(cols.join('\t'));
+    });
+    const tsv = rows.join('\n');
+    navigator.clipboard.writeText(tsv);
+}
+
 function renderStep4Table(rows, replace = false) {
     let table = $('#step4-results-table');
     if (table.length === 0) {
@@ -126,5 +144,9 @@ $(document).ready(function () {
     $('#clear-step4').on('click', function () {
         $('#step4-results-table').remove();
         step4Results = [];
+    });
+
+    $('#copy-step4-results').on('click', function () {
+        copyTableToClipboard('#step4-results-table');
     });
 });


### PR DESCRIPTION
## Summary
- add copy results buttons to Parse Locations steps 3 and 4
- add copy results button to Find Businesses step 3
- add copy results button to Generate Contacts step 3

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7d4646074833383a3e0842de43fc0