### PR TITLE
Improve copy button reliability across pages

### DIFF
--- a/frontend/js/find_businesses/step3.js
+++ b/frontend/js/find_businesses/step3.js
@@ -15,7 +15,21 @@ function copyTableToClipboard(selector) {
     rows.push(cols.join('\t'));
   });
   var tsv = rows.join('\n');
-  navigator.clipboard.writeText(tsv);
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(tsv).catch(function () {
+      fallbackCopy(tsv);
+    });
+  } else {
+    fallbackCopy(tsv);
+  }
+}
+
+function fallbackCopy(text) {
+  var temp = $('<textarea>');
+  $('body').append(temp);
+  temp.val(text).select();
+  document.execCommand('copy');
+  temp.remove();
 }
 
 $(document).ready(function () {

--- a/frontend/js/generate_contacts/step3.js
+++ b/frontend/js/generate_contacts/step3.js
@@ -15,7 +15,21 @@ function copyTableToClipboard(selector) {
     rows.push(cols.join('\t'));
   });
   var tsv = rows.join('\n');
-  navigator.clipboard.writeText(tsv);
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(tsv).catch(function () {
+      fallbackCopy(tsv);
+    });
+  } else {
+    fallbackCopy(tsv);
+  }
+}
+
+function fallbackCopy(text) {
+  var temp = $('<textarea>');
+  $('body').append(temp);
+  temp.val(text).select();
+  document.execCommand('copy');
+  temp.remove();
 }
 
 $(document).ready(function () {

--- a/frontend/js/parse_locations/step3.js
+++ b/frontend/js/parse_locations/step3.js
@@ -17,7 +17,21 @@ function copyTableToClipboard(selector) {
         rows.push(cols.join('\t'));
     });
     const tsv = rows.join('\n');
-    navigator.clipboard.writeText(tsv);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(tsv).catch(function () {
+            fallbackCopy(tsv);
+        });
+    } else {
+        fallbackCopy(tsv);
+    }
+}
+
+function fallbackCopy(text) {
+    const temp = $('<textarea>');
+    $('body').append(temp);
+    temp.val(text).select();
+    document.execCommand('copy');
+    temp.remove();
 }
 
 function renderStep3Table(rows, replace = false) {

--- a/frontend/js/parse_locations/step4.js
+++ b/frontend/js/parse_locations/step4.js
@@ -19,7 +19,21 @@ function copyTableToClipboard(selector) {
         rows.push(cols.join('\t'));
     });
     const tsv = rows.join('\n');
-    navigator.clipboard.writeText(tsv);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(tsv).catch(function () {
+            fallbackCopy(tsv);
+        });
+    } else {
+        fallbackCopy(tsv);
+    }
+}
+
+function fallbackCopy(text) {
+    const temp = $('<textarea>');
+    $('body').append(temp);
+    temp.val(text).select();
+    document.execCommand('copy');
+    temp.remove();
 }
 
 function renderStep4Table(rows, replace = false) {


### PR DESCRIPTION
## Summary
- Ensure all result tables can be copied by adding a fallback clipboard method
- Apply consistent copy logic to Find Businesses, Generate Contacts, and Parse Locations pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd855161a88333871b4bb6b89722df