### PR TITLE
Add duplicate removal to prioritize businesses step

### DIFF
--- a/frontend/html/prioritize_businesses.html
+++ b/frontend/html/prioritize_businesses.html
@@ -30,6 +30,7 @@
         <label>Paste TSV Data:</label><br>
         <textarea name="tsv_text" id="tsv-input"></textarea><br>
         <button type="submit">Load Data</button>
+        <button type="button" id="remove-duplicates">Remove Duplicate Businesses</button>
         <button type="button" id="clear-step1">Clear Step 1</button>
     </form>
 


### PR DESCRIPTION
## Summary
- Add a "Remove Duplicate Businesses" button to the prioritize businesses step 1 form
- Implement client-side deduplication by `business_name` with alerts for missing data and no duplicates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0e50da93483339cfb5a61820762f2