### PR TITLE
Show row index in prioritize businesses step 1

### DIFF
--- a/frontend/js/prioritize_businesses/step1.js
+++ b/frontend/js/prioritize_businesses/step1.js
@@ -120,13 +120,13 @@ function renderDataTable(data) {
     $("#table-container").html("No rows");
     return;
   }
-  var html = "<table><thead><tr>";
+  var html = "<table><thead><tr><th>index</th>";
   Object.keys(data[0]).forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
   html += "</tr></thead><tbody>";
-  data.forEach(function (row) {
-    html += "<tr>";
+  data.forEach(function (row, idx) {
+    html += "<tr><td>" + idx + "</td>";
     Object.values(row).forEach(function (val) {
       html += "<td>" + val + "</td>";
     });


### PR DESCRIPTION
## Summary
- Display the row index when loading TSV data in Prioritize Businesses step 1

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c491a488388333bf92c83749fba8b3