### PR TITLE
feat: score businesses and parse priorities

### DIFF
--- a/backend/prioritize_businesses/step3.py
+++ b/backend/prioritize_businesses/step3.py
@@ -1,14 +1,14 @@
 from flask import Blueprint, jsonify, request
 from flask import Blueprint, jsonify, request
 
-from .processing import parse_results_to_contacts
+from .processing import parse_results_to_priorities
 
 step3_bp = Blueprint("prioritize_businesses_step3", __name__)
 
 
-@step3_bp.route("/prioritize_businesses/parse_contacts", methods=["POST"])
-def parse_contacts_endpoint():
-    """Parse Step 2 results into contact rows."""
+@step3_bp.route("/prioritize_businesses/parse_priorities", methods=["POST"])
+def parse_priorities_endpoint():
+    """Parse Step 2 results into prioritized rows."""
     results = request.json.get("results", [])
-    contacts = parse_results_to_contacts(results)
-    return jsonify(contacts)
+    priorities = parse_results_to_priorities(results)
+    return jsonify(priorities)

--- a/frontend/html/prioritize_businesses.html
+++ b/frontend/html/prioritize_businesses.html
@@ -65,7 +65,7 @@
     <button id="parse-btn">Parse Step 2 Results</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
     <button type="button" id="copy-step3-results">Copy Results</button>
-    <div id="contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
+    <div id="priorities-container" class="scrollable-output" style="margin-top:1em;"></div>
 </div>
 
 <script src="{{ url_for('static', filename='prioritize_businesses/step1.js') }}"></script>

--- a/frontend/js/prioritize_businesses/step2.js
+++ b/frontend/js/prioritize_businesses/step2.js
@@ -141,37 +141,21 @@ $("#cancel-step2").on("click", function () {
 });
 
 $(document).ready(function () {
-  var defaultInstructions = `You are a contact generation expert for sales.
+  var defaultInstructions = `You are a prioritization expert.  Score each business out of 100 using the following logic.
 
-For the business provided, find all key contacts. Prioritize:
-– Founders
-– COOs
-– Heads of Operations
-– Other senior decision-makers
+- Service Type (max 30 pts): commercial = 30; residential = 6–9; mixed = 18–21.
+- Specialized Offerings (max 30 pts): low voltage = 30; BDA/emergency = 30; security cameras = 21; other security/building tech = 15–18.
+- Company Size (max 20 pts): 10–20 employees = 20 (ideal); 1–9 = 12–14; 21–50 = 10–12; 50+ = 6–9.
+- Company Filter: if company is TK, Otis, Schindler, Kone, Vivint, or ADT, score = 0. Otherwise, apply rules above.
+- Website Presence (±20 pts): clear commercial/low-voltage services = +6; no services = −6; relevant job postings = +3–6; outdated/no site = −6.
 
-Required output format:
-Return results as a JSON array of objects.
-Each object must contain:
-- firstname
-- lastname
-- role
-- email (if you can't find their email directly guess it)
+ONLY RETURN OUTPUTS MATCHING THE EXAMPLE STRUCTURE
 
-⚠️ Do not include company name, emails, or any extra explanation.
-⚠️ Output only the raw JSON.
-
-Example input:
-ABC Company
-
-Example output:
-[
-  { "firstname": "John", "lastname": "Smith", "role": "Founder", "email": "john.smith@abccompany.com" },
-  { "firstname": "Jane", "lastname": "Doe", "role": "COO", "email": "jane.doe@abccompany.com" },
-  { "firstname": "Michael", "lastname": "Johnson", "role": "Head of Operations", "email": "michael.johnson@abccompany.com" },
-  { "firstname": "Ryan", "lastname": "Patel", "role": "Founder", "email": "ryan.patel@abccompany.com" },
-  { "firstname": "Laura", "lastname": "Nguyen", "role": "VP of Operations", "email": "laura.nguyen@abccompany.com" },
-  { "firstname": "Carlos", "lastname": "Rivera", "role": "COO", "email": "carlos.rivera@abccompany.com" }
-]`;
+Example outputs: 
+[40, "mostly residential with a strong website and no specialized offerings mentioned"] 
+[12, "residential focus, very small team, no online presence"]
+[92, "commercial, ideal size, multiple specialized services, strong website"]
+[55, "mixed services, mid-size team, cameras only, poor website"]`;
   $("#instructions").val(defaultInstructions);
   var defaultPrompt = "{business_name} {website}";
   var savedPrompt = localStorage.getItem("prioritize_businesses_step2_prompt");

--- a/frontend/js/prioritize_businesses/step3.js
+++ b/frontend/js/prioritize_businesses/step3.js
@@ -1,4 +1,4 @@
-var parsedContacts = [];
+var parsedPriorities = [];
 
 function copyTableToClipboard(selector) {
   var table = $(selector);
@@ -33,20 +33,20 @@ function fallbackCopy(text) {
 }
 
 $(document).ready(function () {
-  var saved = localStorage.getItem("prioritize_businesses_saved_contacts");
+  var saved = localStorage.getItem("prioritize_businesses_saved_priorities");
   if (saved) {
     try {
-      parsedContacts = JSON.parse(saved);
-      renderContactsTable(parsedContacts);
+      parsedPriorities = JSON.parse(saved);
+      renderPrioritiesTable(parsedPriorities);
     } catch (e) {
       console.error(e);
     }
   }
 });
 
-function renderContactsTable(data) {
+function renderPrioritiesTable(data) {
   if (!data.length) {
-    $("#contacts-container").html("No contacts");
+    $("#priorities-container").html("No data");
     return;
   }
   var cols = Object.keys(data[0]);
@@ -55,7 +55,7 @@ function renderContactsTable(data) {
     if (b === "business_name") return 1;
     return 0;
   });
-  var html = '<table id="contacts-results-table"><thead><tr>';
+  var html = '<table id="priorities-results-table"><thead><tr>';
   cols.forEach(function (col) {
     html += "<th>" + col + "</th>";
   });
@@ -68,7 +68,7 @@ function renderContactsTable(data) {
     html += "</tr>";
   });
   html += "</tbody></table>";
-  $("#contacts-container").html(html);
+  $("#priorities-container").html(html);
 }
 
 $("#parse-btn").on("click", function () {
@@ -77,14 +77,17 @@ $("#parse-btn").on("click", function () {
     return;
   }
   $.ajax({
-    url: "/prioritize_businesses/parse_contacts",
+    url: "/prioritize_businesses/parse_priorities",
     method: "POST",
     contentType: "application/json",
     data: JSON.stringify({ results: Object.values(step2Results) }),
     success: function (data) {
-      parsedContacts = parsedContacts.concat(data);
-      renderContactsTable(parsedContacts);
-      localStorage.setItem("prioritize_businesses_saved_contacts", JSON.stringify(parsedContacts));
+      parsedPriorities = parsedPriorities.concat(data);
+      renderPrioritiesTable(parsedPriorities);
+      localStorage.setItem(
+        "prioritize_businesses_saved_priorities",
+        JSON.stringify(parsedPriorities)
+      );
     },
     error: function (xhr) {
       alert(xhr.responseText);
@@ -93,11 +96,11 @@ $("#parse-btn").on("click", function () {
 });
 
 $("#clear-step3").on("click", function () {
-  $("#contacts-container").empty();
-  parsedContacts = [];
-  localStorage.removeItem("prioritize_businesses_saved_contacts");
+  $("#priorities-container").empty();
+  parsedPriorities = [];
+  localStorage.removeItem("prioritize_businesses_saved_priorities");
 });
 
 $("#copy-step3-results").on("click", function () {
-  copyTableToClipboard('#contacts-results-table');
+  copyTableToClipboard('#priorities-results-table');
 });


### PR DESCRIPTION
## Summary
- update prioritization prompt with detailed scoring rubric
- parse step 2 results to include original data plus SCORE and SCORE_RATIONAL
- refresh Step 3 UI and endpoint to handle priorities instead of contacts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4a8b763a88333b8993f70ad1bd6e6