### PR TITLE
Add schema-driven contact formatting step

### DIFF
--- a/backend/generate_contacts/step3.py
+++ b/backend/generate_contacts/step3.py
@@ -1,13 +1,14 @@
 from flask import Blueprint, jsonify, request
 
-from .processing import parse_results_to_contacts
+from .processing import format_contacts_with_schema
 
 step3_bp = Blueprint("step3", __name__)
 
 
 @step3_bp.route("/parse_contacts", methods=["POST"])
 def parse_contacts_endpoint():
-    """Parse Step 2 results into contact rows."""
+    """Format Step 2 results into structured contacts using OpenAI."""
     results = request.json.get("results", [])
-    contacts = parse_results_to_contacts(results)
+    schema_definition = request.json.get("schema", "")
+    contacts = format_contacts_with_schema(results, schema_definition)
     return jsonify(contacts)

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -61,6 +61,31 @@
 
 <div id="step3" style="margin-top:2em;">
     <h2>STEP 3: Parse Contacts</h2>
+    <label for="schema-definition">Schema Definition:</label><br>
+    <textarea id="schema-definition" style="height:200px;">{
+  "name": "ContactList",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "contacts": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "first_name": {"type": "string"},
+            "last_name": {"type": "string"},
+            "role": {"type": "string"},
+            "email": {"type": "string"}
+          },
+          "required": ["first_name", "last_name"],
+          "additionalProperties": true
+        }
+      }
+    },
+    "required": ["contacts"],
+    "additionalProperties": false
+  }
+}</textarea><br>
     <button id="parse-btn">Parse Step 2 Results</button>
     <button type="button" id="clear-step3">Clear Step 3</button>
     <button type="button" id="copy-step3-results">Copy Results</button>

--- a/frontend/js/generate_contacts/step3.js
+++ b/frontend/js/generate_contacts/step3.js
@@ -42,6 +42,10 @@ $(document).ready(function () {
       console.error(e);
     }
   }
+  var storedSchema = localStorage.getItem("saved_schema_definition");
+  if (storedSchema) {
+    $("#schema-definition").val(storedSchema);
+  }
 });
 
 function renderContactsTable(data) {
@@ -76,12 +80,20 @@ $("#parse-btn").on("click", function () {
     alert("No Step 2 results to parse");
     return;
   }
+  var schemaDefinition = $("#schema-definition").val();
+  localStorage.setItem("saved_schema_definition", schemaDefinition);
   $.ajax({
     url: "/parse_contacts",
     method: "POST",
     contentType: "application/json",
-    data: JSON.stringify({ results: Object.values(step2Results) }),
+    data: JSON.stringify({
+      results: Object.values(step2Results),
+      schema: schemaDefinition,
+    }),
     success: function (data) {
+      if (!Array.isArray(data) && data && Array.isArray(data.contacts)) {
+        data = data.contacts;
+      }
       parsedContacts = parsedContacts.concat(data);
       renderContactsTable(parsedContacts);
       localStorage.setItem("saved_contacts", JSON.stringify(parsedContacts));


### PR DESCRIPTION
## Summary
- add a default contact schema and new helper that calls a low-cost OpenAI model to format Step 2 results into the schema
- update the Step 3 API endpoint to forward the schema definition and return the structured contacts
- expose a schema definition textarea in the UI and persist it so Step 3 can send it with parsing requests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf39d177108333befadaf51e39d417