### PR TITLE
Add guess method workflow for generate contacts

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,9 @@ from backend.generate_contacts import (
     simple_step1_bp as gc_simple_step1_bp,
     simple_step2_bp as gc_simple_step2_bp,
     simple_step3_bp as gc_simple_step3_bp,
+    guess_step1_bp as gc_guess_step1_bp,
+    guess_step2_bp as gc_guess_step2_bp,
+    guess_step3_bp as gc_guess_step3_bp,
 )
 from backend.prioritize_businesses import (
     step1_bp as prioritize_step1_bp,
@@ -48,6 +51,9 @@ def create_app():
     app.register_blueprint(gc_simple_step1_bp)
     app.register_blueprint(gc_simple_step2_bp)
     app.register_blueprint(gc_simple_step3_bp)
+    app.register_blueprint(gc_guess_step1_bp)
+    app.register_blueprint(gc_guess_step2_bp)
+    app.register_blueprint(gc_guess_step3_bp)
 
     return app
 

--- a/backend/generate_contacts/__init__.py
+++ b/backend/generate_contacts/__init__.py
@@ -6,10 +6,18 @@ from .simple_method import (
     simple_step2_bp,
     simple_step3_bp,
 )
+from .guess_method import (
+    guess_step1_bp,
+    guess_step2_bp,
+    guess_step3_bp,
+)
 
 __all__ = [
     "pages_bp",
     "simple_step1_bp",
     "simple_step2_bp",
     "simple_step3_bp",
+    "guess_step1_bp",
+    "guess_step2_bp",
+    "guess_step3_bp",
 ]

--- a/backend/generate_contacts/guess_method/__init__.py
+++ b/backend/generate_contacts/guess_method/__init__.py
@@ -1,3 +1,7 @@
-"""Placeholder package for the guess contact generation method."""
+"""Blueprint registrations for the guess contact generation method."""
 
-__all__ = []
+from .step1 import guess_step1_bp
+from .step2 import guess_step2_bp
+from .step3 import guess_step3_bp
+
+__all__ = ["guess_step1_bp", "guess_step2_bp", "guess_step3_bp"]

--- a/backend/generate_contacts/guess_method/data_store.py
+++ b/backend/generate_contacts/guess_method/data_store.py
@@ -1,0 +1,6 @@
+"""In-memory storage for the guess contact generation method."""
+
+import pandas as pd
+
+# Separate storage from the simple method so each workflow can run independently.
+DATAFRAME: pd.DataFrame | None = None

--- a/backend/generate_contacts/guess_method/step1.py
+++ b/backend/generate_contacts/guess_method/step1.py
@@ -1,0 +1,26 @@
+"""Upload endpoints for the guess contact generation method."""
+
+import io
+
+import pandas as pd
+from flask import Blueprint, request
+
+from . import data_store
+
+guess_step1_bp = Blueprint(
+    "generate_contacts_guess_step1",
+    __name__,
+    url_prefix="/generate_contacts/guess",
+)
+
+
+@guess_step1_bp.route("/upload", methods=["POST"])
+def upload():
+    """Load TSV data sent from the client and store it for the guess method."""
+    tsv_text = request.form.get("tsv_text", "").strip()
+    if not tsv_text:
+        return "No TSV data provided", 400
+
+    data_frame = pd.read_csv(io.StringIO(tsv_text), sep="\t", index_col=None)
+    data_store.DATAFRAME = data_frame
+    return data_frame.to_json(orient="records")

--- a/backend/generate_contacts/guess_method/step2.py
+++ b/backend/generate_contacts/guess_method/step2.py
@@ -1,0 +1,45 @@
+"""Processing endpoints for the guess contact generation method."""
+
+import pandas as pd
+from flask import Blueprint, jsonify, request
+
+from . import data_store
+from ..simple_method.processing import apply_prompt_to_dataframe, apply_prompt_to_row
+
+guess_step2_bp = Blueprint(
+    "generate_contacts_guess_step2",
+    __name__,
+    url_prefix="/generate_contacts/guess",
+)
+
+
+@guess_step2_bp.route("/process", methods=["POST"])
+def process():
+    """Apply the prompt to every row in the stored dataframe."""
+    if data_store.DATAFRAME is None:
+        return "No data loaded", 400
+
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    results = apply_prompt_to_dataframe(data_store.DATAFRAME, instructions, prompt)
+    return jsonify(results)
+
+
+@guess_step2_bp.route("/process_single", methods=["POST"])
+def process_single():
+    """Process a single row of data using the configured prompt."""
+    if data_store.DATAFRAME is None:
+        return "No data loaded", 400
+
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    row_index = int(request.json.get("row_index", 0))
+
+    if row_index < 0 or row_index >= len(data_store.DATAFRAME):
+        return "Invalid row index", 400
+
+    row = data_store.DATAFRAME.iloc[row_index]
+    result = apply_prompt_to_row(row, instructions, prompt)
+    new_row = row.where(pd.notna(row), None).to_dict()
+    new_row["result"] = result
+    return jsonify(new_row)

--- a/backend/generate_contacts/guess_method/step3.py
+++ b/backend/generate_contacts/guess_method/step3.py
@@ -1,0 +1,19 @@
+"""Parsing endpoints for the guess contact generation method."""
+
+from flask import Blueprint, jsonify, request
+
+from ..simple_method.processing import parse_results_to_contacts
+
+guess_step3_bp = Blueprint(
+    "generate_contacts_guess_step3",
+    __name__,
+    url_prefix="/generate_contacts/guess",
+)
+
+
+@guess_step3_bp.route("/parse_contacts", methods=["POST"])
+def parse_contacts_endpoint():
+    """Parse Step 2 results into contact rows."""
+    results = request.json.get("results", [])
+    contacts = parse_results_to_contacts(results)
+    return jsonify(contacts)

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -97,8 +97,47 @@
     </section>
 
     <section id="guess-method" class="method-section" aria-hidden="true">
-        <h2>Guess Method</h2>
-        <p>This method is coming soon. Stay tuned for updates!</p>
+        <div id="guess-step1">
+            <h2>STEP 1: Initial Data Load</h2>
+            <form id="guess-upload-form" method="post" enctype="multipart/form-data">
+                <label>Paste TSV Data:</label><br>
+                <textarea name="tsv_text" id="guess-tsv-input"></textarea><br>
+                <button type="submit">Load Data</button>
+                <button type="button" id="guess-clear-step1">Clear Step 1</button>
+            </form>
+
+            <div id="guess-table-container" class="scrollable-output"></div>
+        </div>
+
+        <div id="guess-step2" style="margin-top:2em;">
+            <h2>STEP 2: Generate Contacts</h2>
+            <div id="guess-process-section">
+                <label>Instructions:</label><br>
+                <textarea id="guess-instructions" style="height:80px;"></textarea><br>
+                <label>Prompt (use column names in {braces}):</label><br>
+                  <textarea id="guess-prompt" style="height:100px;"></textarea><br>
+                <label>Row index for single run:</label>
+                <input type="number" id="guess-row-index" value="0" min="0"><br>
+                <label>Start index:</label>
+                <input type="number" id="guess-start-index" value="0" min="0">
+                <label>End index:</label>
+                <input type="number" id="guess-end-index" value="0" min="0"><br>
+                <button id="guess-process-single-btn">Process Single Row</button>
+                <button id="guess-process-range-btn">Process Range</button>
+                <button type="button" id="guess-cancel-step2">Cancel Processing</button>
+                <button type="button" id="guess-clear-step2">Clear Results</button>
+
+            </div>
+            <div id="guess-results-container" class="scrollable-output" style="margin-top:1em;"></div>
+        </div>
+
+        <div id="guess-step3" style="margin-top:2em;">
+            <h2>STEP 3: Parse Contacts</h2>
+            <button id="guess-parse-btn">Parse Step 2 Results</button>
+            <button type="button" id="guess-clear-step3">Clear Step 3</button>
+            <button type="button" id="guess-copy-step3-results">Copy Results</button>
+            <div id="guess-contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
+        </div>
     </section>
 </div>
 
@@ -123,5 +162,8 @@
 <script src="{{ url_for('static', filename='generate_contacts/simple_method/step1.js') }}"></script>
 <script src="{{ url_for('static', filename='generate_contacts/simple_method/step2.js') }}"></script>
 <script src="{{ url_for('static', filename='generate_contacts/simple_method/step3.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step1.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step2.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step3.js') }}"></script>
 </body>
 </html>

--- a/frontend/js/generate_contacts/guess_method/step1.js
+++ b/frontend/js/generate_contacts/guess_method/step1.js
@@ -1,0 +1,136 @@
+(function () {
+  const STORAGE_KEYS = {
+    tsv: "generate_contacts_guess_step1_tsv",
+    instructions: "generate_contacts_guess_step1_instructions",
+    prompt: "generate_contacts_guess_step1_prompt",
+  };
+
+  const LEGACY_STORAGE_KEYS = {
+    tsv: "generate_contacts_guess_step1_tsv_legacy",
+    instructions: "generate_contacts_guess_step1_instructions_legacy",
+    prompt: "generate_contacts_guess_step1_prompt_legacy",
+  };
+
+  function loadValueWithFallback(key) {
+    const current = localStorage.getItem(STORAGE_KEYS[key]) || "";
+    if (current && current.length) {
+      return current;
+    }
+    const legacyKey = LEGACY_STORAGE_KEYS[key];
+    if (!legacyKey) {
+      return "";
+    }
+    const legacyValue = localStorage.getItem(legacyKey) || "";
+    if (legacyValue && legacyValue.length) {
+      localStorage.setItem(STORAGE_KEYS[key], legacyValue);
+      return legacyValue;
+    }
+    return "";
+  }
+
+  function loadSavedSetup() {
+    const savedTsv = loadValueWithFallback("tsv");
+    const savedInstructions = loadValueWithFallback("instructions");
+    const savedPrompt = loadValueWithFallback("prompt");
+
+    return { savedTsv, savedInstructions, savedPrompt };
+  }
+
+  function renderTable(data) {
+    if (!data.length) {
+      $("#guess-table-container").html("No rows");
+      return;
+    }
+    let html = "<table><thead><tr><th>index</th>";
+    Object.keys(data[0]).forEach(function (col) {
+      html += "<th>" + col + "</th>";
+    });
+    html += "</tr></thead><tbody>";
+    data.forEach(function (row, idx) {
+      html += "<tr><td>" + idx + "</td>";
+      Object.values(row).forEach(function (val) {
+        html += "<td>" + val + "</td>";
+      });
+      html += "</tr>";
+    });
+    html += "</tbody></table>";
+    $("#guess-table-container").html(html);
+  }
+
+  function autoPopulateFromSaved() {
+    const setup = loadSavedSetup();
+    let tsvData = setup.savedTsv;
+
+    if (!tsvData) {
+      tsvData =
+        "business_name\tLocation\tPopulation\twebsite\n" +
+        "Origin Point\tmadison wi Downtown\t25000\thttps://www.originpoint.com/branches/wi/madison";
+    }
+
+    $("#guess-tsv-input").val(tsvData);
+    $("#guess-instructions").val(setup.savedInstructions);
+    $("#guess-prompt").val(setup.savedPrompt);
+
+    if (tsvData) {
+      const formData = new FormData();
+      formData.append("tsv_text", tsvData);
+      $.ajax({
+        url: "/generate_contacts/guess/upload",
+        method: "POST",
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function (data) {
+          renderTable(JSON.parse(data));
+        },
+        error: function (xhr) {
+          console.error(xhr.responseText);
+        },
+      });
+    }
+  }
+
+  function autoSave() {
+    localStorage.setItem(STORAGE_KEYS.tsv, $("#guess-tsv-input").val());
+    localStorage.setItem(
+      STORAGE_KEYS.instructions,
+      $("#guess-instructions").val()
+    );
+    localStorage.setItem(STORAGE_KEYS.prompt, $("#guess-prompt").val());
+    Object.values(LEGACY_STORAGE_KEYS).forEach(function (legacyKey) {
+      localStorage.removeItem(legacyKey);
+    });
+  }
+
+  $(document).ready(function () {
+    autoPopulateFromSaved();
+    $("#guess-tsv-input, #guess-instructions, #guess-prompt").on(
+      "input",
+      autoSave
+    );
+    $(window).on("beforeunload", autoSave);
+  });
+
+  $("#guess-upload-form").on("submit", function (e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    $.ajax({
+      url: "/generate_contacts/guess/upload",
+      method: "POST",
+      data: formData,
+      processData: false,
+      contentType: false,
+      success: function (data) {
+        renderTable(JSON.parse(data));
+        autoSave();
+      },
+      error: function (xhr) {
+        alert(xhr.responseText);
+      },
+    });
+  });
+
+  $("#guess-clear-step1").on("click", function () {
+    $("#guess-table-container").empty();
+  });
+})();

--- a/frontend/js/generate_contacts/guess_method/step2.js
+++ b/frontend/js/generate_contacts/guess_method/step2.js
@@ -1,0 +1,227 @@
+(function () {
+  const RESULTS_KEY = "generate_contacts_guess_step2_results";
+  const PROMPT_KEY = "generate_contacts_guess_step2_prompt";
+
+  function replaceStep2Results(nextResults) {
+    window.guessStep2Results = nextResults || {};
+    return window.guessStep2Results;
+  }
+
+  let step2Results = replaceStep2Results(window.guessStep2Results || {});
+  let cancelProcessing = false;
+  let currentRequest = null;
+
+  function getBusinessNameKey(obj) {
+    for (const key in obj) {
+      const lower = key.toLowerCase();
+      if (
+        lower === "business name" ||
+        lower === "business_name" ||
+        (lower.includes("business") && lower.includes("name"))
+      ) {
+        return key;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(obj, "name")) return "name";
+    return Object.keys(obj)[0];
+  }
+
+  function renderResultsTable(resultsObj) {
+    const indexes = Object.keys(resultsObj).sort(function (a, b) {
+      return parseInt(a, 10) - parseInt(b, 10);
+    });
+    if (!indexes.length) {
+      $("#guess-results-container").html("No results");
+      return;
+    }
+    const firstRow = resultsObj[indexes[0]];
+    const businessKey = getBusinessNameKey(firstRow);
+    let html =
+      "<table><thead><tr><th>index</th><th>" +
+      businessKey +
+      "</th><th>result</th></tr></thead><tbody>";
+    indexes.forEach(function (idx) {
+      const row = resultsObj[idx];
+      html +=
+        "<tr><td>" +
+        idx +
+        "</td><td>" +
+        (row[businessKey] || "") +
+        "</td><td>" +
+        row.result +
+        "</td></tr>";
+    });
+    html += "</tbody></table>";
+    $("#guess-results-container").html(html);
+  }
+
+  function storeResults() {
+    localStorage.setItem(RESULTS_KEY, JSON.stringify(step2Results));
+  }
+
+  function runSingleRequest(payload, onSuccess, onError) {
+    currentRequest = $.ajax({
+      url: "/generate_contacts/guess/process_single",
+      method: "POST",
+      contentType: "application/json",
+      data: JSON.stringify(payload),
+      success: onSuccess,
+      error: onError,
+    });
+  }
+
+  $("#guess-process-range-btn").on("click", function () {
+    const prompt = $("#guess-prompt").val();
+    const instructions = $("#guess-instructions").val();
+    const start = parseInt($("#guess-start-index").val(), 10) || 0;
+    const end = parseInt($("#guess-end-index").val(), 10) || 0;
+    if (end < start) {
+      alert("End index must be greater than or equal to start index");
+      return;
+    }
+    const indexes = [];
+    for (let i = start; i <= end; i += 1) {
+      indexes.push(i);
+    }
+
+    cancelProcessing = false;
+
+    function processNext(pos) {
+      if (cancelProcessing || pos >= indexes.length) return;
+      const idx = indexes[pos];
+      function send(attempt) {
+        runSingleRequest(
+          {
+            prompt: prompt,
+            instructions: instructions,
+            row_index: idx,
+          },
+          function (data) {
+            data.index = idx;
+            step2Results[idx] = data;
+            renderResultsTable(step2Results);
+            storeResults();
+            if (!cancelProcessing) {
+              setTimeout(function () {
+                processNext(pos + 1);
+              }, 300);
+            }
+          },
+          function (xhr) {
+            console.error("Error processing row", idx, xhr.responseText);
+            if (!cancelProcessing) {
+              if (attempt < 1) {
+                setTimeout(function () {
+                  send(attempt + 1);
+                }, 300);
+              } else {
+                setTimeout(function () {
+                  processNext(pos + 1);
+                }, 300);
+              }
+            }
+          }
+        );
+      }
+      send(0);
+    }
+    processNext(0);
+  });
+
+  $("#guess-process-single-btn").on("click", function () {
+    const prompt = $("#guess-prompt").val();
+    const instructions = $("#guess-instructions").val();
+    const rowIndex = parseInt($("#guess-row-index").val(), 10) || 0;
+    runSingleRequest(
+      {
+        prompt: prompt,
+        instructions: instructions,
+        row_index: rowIndex,
+      },
+      function (data) {
+        data.index = rowIndex;
+        step2Results[rowIndex] = data;
+        renderResultsTable(step2Results);
+        storeResults();
+      },
+      function (xhr) {
+        console.error("Error processing row", rowIndex, xhr.responseText);
+      }
+    );
+  });
+
+  $("#guess-cancel-step2").on("click", function () {
+    cancelProcessing = true;
+    if (currentRequest) {
+      currentRequest.abort();
+    }
+  });
+
+  $(document).ready(function () {
+    const defaultInstructions = `You are a contact generation expert for sales.
+
+For the business provided, find all key contacts. Prioritize:
+– Founders
+– COOs
+– Heads of Operations
+– Other senior decision-makers
+
+Required output format:
+Return results as a JSON array of objects.
+Each object must contain:
+- firstname
+- lastname
+- role
+- email (if you can't find their email directly guess it)
+
+⚠️ Do not include company name, emails, or any extra explanation.
+⚠️ Output only the raw JSON.
+
+Example input:
+ABC Company
+
+Example output:
+[
+  { "firstname": "John", "lastname": "Smith", "role": "Founder", "email": "john.smith@abccompany.com" },
+  { "firstname": "Jane", "lastname": "Doe", "role": "COO", "email": "jane.doe@abccompany.com" },
+  { "firstname": "Michael", "lastname": "Johnson", "role": "Head of Operations", "email": "michael.johnson@abccompany.com" },
+  { "firstname": "Ryan", "lastname": "Patel", "role": "Founder", "email": "ryan.patel@abccompany.com" },
+  { "firstname": "Laura", "lastname": "Nguyen", "role": "VP of Operations", "email": "laura.nguyen@abccompany.com" },
+  { "firstname": "Carlos", "lastname": "Rivera", "role": "COO", "email": "carlos.rivera@abccompany.com" }
+]`;
+    $("#guess-instructions").val(defaultInstructions);
+    const defaultPrompt = "{business_name} {website}";
+    const savedPrompt = localStorage.getItem(PROMPT_KEY);
+    if (savedPrompt && savedPrompt.trim() !== "") {
+      $("#guess-prompt").val(savedPrompt);
+    } else {
+      $("#guess-prompt").val(defaultPrompt);
+    }
+    $("#guess-prompt").on("input", function () {
+      const value = $(this).val();
+      localStorage.setItem(PROMPT_KEY, value);
+    });
+
+    const saved = localStorage.getItem(RESULTS_KEY);
+    if (saved) {
+      try {
+        step2Results = replaceStep2Results(JSON.parse(saved));
+        renderResultsTable(step2Results);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    $("#guess-clear-step2").on("click", function () {
+      step2Results = replaceStep2Results({});
+      $("#guess-results-container").empty();
+      localStorage.removeItem(RESULTS_KEY);
+    });
+  });
+
+  $(window).on("beforeunload", function () {
+    const promptValue = $("#guess-prompt").val();
+    localStorage.setItem(PROMPT_KEY, promptValue);
+    storeResults();
+  });
+})();

--- a/frontend/js/generate_contacts/guess_method/step3.js
+++ b/frontend/js/generate_contacts/guess_method/step3.js
@@ -1,0 +1,127 @@
+(function () {
+  let parsedContacts = [];
+  const CONTACTS_KEY = "generate_contacts_guess_saved_contacts";
+  const STEP2_RESULTS_KEY = "generate_contacts_guess_step2_results";
+
+  function ensureStep2Results() {
+    if (window.guessStep2Results && typeof window.guessStep2Results === "object") {
+      return window.guessStep2Results;
+    }
+    const saved = localStorage.getItem(STEP2_RESULTS_KEY);
+    if (saved) {
+      try {
+        window.guessStep2Results = JSON.parse(saved);
+        return window.guessStep2Results;
+      } catch (e) {
+        console.error("Unable to parse Step 2 results", e);
+      }
+    }
+    window.guessStep2Results = {};
+    return window.guessStep2Results;
+  }
+
+  function fallbackCopy(text) {
+    const temp = $("<textarea>");
+    $("body").append(temp);
+    temp.val(text).select();
+    document.execCommand("copy");
+    temp.remove();
+  }
+
+  function copyTableToClipboard(selector) {
+    const table = $(selector);
+    if (table.length === 0) {
+      alert("No data to copy.");
+      return;
+    }
+    const rows = [];
+    table.find("tr").each(function () {
+      const cols = [];
+      $(this)
+        .find("th,td")
+        .each(function () {
+          cols.push($(this).text());
+        });
+      rows.push(cols.join("\t"));
+    });
+    const tsv = rows.join("\n");
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(tsv).catch(function () {
+        fallbackCopy(tsv);
+      });
+    } else {
+      fallbackCopy(tsv);
+    }
+  }
+
+  function renderContactsTable(data) {
+    if (!data.length) {
+      $("#guess-contacts-container").html("No contacts");
+      return;
+    }
+    const cols = Object.keys(data[0]);
+    cols.sort(function (a, b) {
+      if (a === "business_name") return -1;
+      if (b === "business_name") return 1;
+      return 0;
+    });
+    let html = '<table id="guess-contacts-results-table"><thead><tr>';
+    cols.forEach(function (col) {
+      html += "<th>" + col + "</th>";
+    });
+    html += "</tr></thead><tbody>";
+    data.forEach(function (row) {
+      html += "<tr>";
+      cols.forEach(function (k) {
+        html += "<td>" + (row[k] || "") + "</td>";
+      });
+      html += "</tr>";
+    });
+    html += "</tbody></table>";
+    $("#guess-contacts-container").html(html);
+  }
+
+  $(document).ready(function () {
+    const saved = localStorage.getItem(CONTACTS_KEY);
+    if (saved) {
+      try {
+        parsedContacts = JSON.parse(saved);
+        renderContactsTable(parsedContacts);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  });
+
+  $("#guess-parse-btn").on("click", function () {
+    const currentStep2Results = ensureStep2Results();
+    if (Object.keys(currentStep2Results).length === 0) {
+      alert("No Step 2 results to parse");
+      return;
+    }
+    $.ajax({
+      url: "/generate_contacts/guess/parse_contacts",
+      method: "POST",
+      contentType: "application/json",
+      data: JSON.stringify({ results: Object.values(currentStep2Results) }),
+      success: function (data) {
+        parsedContacts = parsedContacts.concat(data);
+        renderContactsTable(parsedContacts);
+        localStorage.setItem(CONTACTS_KEY, JSON.stringify(parsedContacts));
+      },
+      error: function (xhr) {
+        alert(xhr.responseText);
+      },
+    });
+  });
+
+  $("#guess-clear-step3").on("click", function () {
+    $("#guess-contacts-container").empty();
+    parsedContacts = [];
+    localStorage.removeItem(CONTACTS_KEY);
+  });
+
+  $("#guess-copy-step3-results").on("click", function () {
+    copyTableToClipboard("#guess-contacts-results-table");
+  });
+})();


### PR DESCRIPTION
## Summary
- add backend blueprints and storage to support the guess generate-contacts method
- mirror the simple method UI/JS so the guess method offers steps 1-3 with identical behavior

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d0352f60f0833385aa2153f03eb302