### PR TITLE
Refine guess method email and contact workflows

### DIFF
--- a/backend/generate_contacts/guess_method/step3.py
+++ b/backend/generate_contacts/guess_method/step3.py
@@ -1,8 +1,10 @@
-"""Parsing endpoints for the guess contact generation method."""
+"""Processing endpoints for the guess contact generation method (Step 3)."""
 
+import pandas as pd
 from flask import Blueprint, jsonify, request
 
-from ..simple_method.processing import parse_results_to_contacts
+from . import data_store
+from ..simple_method.processing import apply_prompt_to_dataframe, apply_prompt_to_row
 
 guess_step3_bp = Blueprint(
     "generate_contacts_guess_step3",
@@ -11,9 +13,43 @@ guess_step3_bp = Blueprint(
 )
 
 
-@guess_step3_bp.route("/parse_contacts", methods=["POST"])
-def parse_contacts_endpoint():
-    """Parse Step 2 results into contact rows."""
-    results = request.json.get("results", [])
-    contacts = parse_results_to_contacts(results)
-    return jsonify(contacts)
+@guess_step3_bp.route("/step3/process", methods=["POST"])
+def process():
+    """Apply the Step 3 prompt to every row in the stored dataframe."""
+    if data_store.DATAFRAME is None:
+        return "No data loaded", 400
+
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    raw_results = apply_prompt_to_dataframe(
+        data_store.DATAFRAME, instructions, prompt
+    )
+    transformed = []
+    for row in raw_results:
+        if isinstance(row, dict):
+            updated_row = {k: v for k, v in row.items() if k != "result"}
+            updated_row["raw_contacts"] = row.get("result", "")
+        else:
+            updated_row = {"raw_contacts": row}
+        transformed.append(updated_row)
+    return jsonify(transformed)
+
+
+@guess_step3_bp.route("/step3/process_single", methods=["POST"])
+def process_single():
+    """Process a single row of data using the Step 3 prompt."""
+    if data_store.DATAFRAME is None:
+        return "No data loaded", 400
+
+    prompt = request.json.get("prompt", "")
+    instructions = request.json.get("instructions", "")
+    row_index = int(request.json.get("row_index", 0))
+
+    if row_index < 0 or row_index >= len(data_store.DATAFRAME):
+        return "Invalid row index", 400
+
+    row = data_store.DATAFRAME.iloc[row_index]
+    result = apply_prompt_to_row(row, instructions, prompt)
+    new_row = row.where(pd.notna(row), None).to_dict()
+    new_row["raw_contacts"] = result
+    return jsonify(new_row)

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -110,7 +110,7 @@
         </div>
 
         <div id="guess-step2" style="margin-top:2em;">
-            <h2>STEP 2: Generate Contacts</h2>
+            <h2>STEP 2: Find Public Emails</h2>
             <div id="guess-process-section">
                 <label>Instructions:</label><br>
                 <textarea id="guess-instructions" style="height:80px;"></textarea><br>
@@ -124,6 +124,7 @@
                 <input type="number" id="guess-end-index" value="0" min="0"><br>
                 <button id="guess-process-single-btn">Process Single Row</button>
                 <button id="guess-process-range-btn">Process Range</button>
+                <button type="button" id="guess-extract-domain-btn">Extract Domains</button>
                 <button type="button" id="guess-cancel-step2">Cancel Processing</button>
                 <button type="button" id="guess-clear-step2">Clear Results</button>
 
@@ -132,11 +133,25 @@
         </div>
 
         <div id="guess-step3" style="margin-top:2em;">
-            <h2>STEP 3: Parse Contacts</h2>
-            <button id="guess-parse-btn">Parse Step 2 Results</button>
-            <button type="button" id="guess-clear-step3">Clear Step 3</button>
-            <button type="button" id="guess-copy-step3-results">Copy Results</button>
-            <div id="guess-contacts-container" class="scrollable-output" style="margin-top:1em;"></div>
+            <h2>STEP 3: Find Target Contacts</h2>
+            <div id="guess-step3-process-section">
+                <label>Instructions:</label><br>
+                <textarea id="guess-step3-instructions" style="height:80px;"></textarea><br>
+                <label>Prompt (use column names in {braces}):</label><br>
+                  <textarea id="guess-step3-prompt" style="height:100px;"></textarea><br>
+                <label>Row index for single run:</label>
+                <input type="number" id="guess-step3-row-index" value="0" min="0"><br>
+                <label>Start index:</label>
+                <input type="number" id="guess-step3-start-index" value="0" min="0">
+                <label>End index:</label>
+                <input type="number" id="guess-step3-end-index" value="0" min="0"><br>
+                <button id="guess-step3-process-single-btn">Process Single Row</button>
+                <button id="guess-step3-process-range-btn">Process Range</button>
+                <button type="button" id="guess-step3-cancel">Cancel Processing</button>
+                <button type="button" id="guess-step3-clear">Clear Results</button>
+                <button type="button" id="guess-step3-copy-results">Copy Results</button>
+            </div>
+            <div id="guess-step3-results-container" class="scrollable-output" style="margin-top:1em;"></div>
         </div>
     </section>
 </div>

--- a/frontend/js/generate_contacts/guess_method/step3.js
+++ b/frontend/js/generate_contacts/guess_method/step3.js
@@ -1,7 +1,12 @@
 (function () {
-  let parsedContacts = [];
-  const CONTACTS_KEY = "generate_contacts_guess_saved_contacts";
   const STEP2_RESULTS_KEY = "generate_contacts_guess_step2_results";
+  const STEP3_RESULTS_KEY = "generate_contacts_guess_step3_results";
+  const STEP3_PROMPT_KEY = "generate_contacts_guess_step3_prompt";
+  const STEP3_INSTRUCTIONS_KEY = "generate_contacts_guess_step3_instructions";
+
+  let step3Results = {};
+  let cancelProcessing = false;
+  let currentRequest = null;
 
   function ensureStep2Results() {
     if (window.guessStep2Results && typeof window.guessStep2Results === "object") {
@@ -12,12 +17,47 @@
       try {
         window.guessStep2Results = JSON.parse(saved);
         return window.guessStep2Results;
-      } catch (e) {
-        console.error("Unable to parse Step 2 results", e);
+      } catch (err) {
+        console.error("Unable to parse Step 2 results", err);
       }
     }
     window.guessStep2Results = {};
     return window.guessStep2Results;
+  }
+
+  function getBusinessNameKey(obj) {
+    if (!obj) {
+      return null;
+    }
+    for (const key in obj) {
+      const lower = key.toLowerCase();
+      if (
+        lower === "business name" ||
+        lower === "business_name" ||
+        (lower.includes("business") && lower.includes("name"))
+      ) {
+        return key;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(obj, "name")) {
+      return "name";
+    }
+    const keys = Object.keys(obj);
+    return keys.length ? keys[0] : null;
+  }
+
+  function formatValue(value) {
+    if (value === null || value === undefined) {
+      return "";
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    try {
+      return JSON.stringify(value);
+    } catch (err) {
+      return String(value);
+    }
   }
 
   function fallbackCopy(text) {
@@ -54,74 +94,254 @@
     }
   }
 
-  function renderContactsTable(data) {
-    if (!data.length) {
-      $("#guess-contacts-container").html("No contacts");
+  function storeStep3Results() {
+    localStorage.setItem(STEP3_RESULTS_KEY, JSON.stringify(step3Results));
+  }
+
+  function persistStep2Results(updatedResults) {
+    window.guessStep2Results = updatedResults;
+    localStorage.setItem(STEP2_RESULTS_KEY, JSON.stringify(updatedResults));
+    $(document).trigger("guessStep2ResultsUpdated");
+  }
+
+  function buildCombinedRows() {
+    const step2Data = ensureStep2Results();
+    const indexes = Object.keys(step2Data).sort(function (a, b) {
+      return parseInt(a, 10) - parseInt(b, 10);
+    });
+    return indexes.map(function (idx) {
+      const baseRow = step2Data[idx] || {};
+      const supplemental = step3Results[idx] || {};
+      const combined = { ...baseRow };
+      if (supplemental && Object.prototype.hasOwnProperty.call(supplemental, "raw_contacts")) {
+        combined.raw_contacts = supplemental.raw_contacts;
+      }
+      combined.index = idx;
+      return combined;
+    });
+  }
+
+  function renderCombinedTable() {
+    const rows = buildCombinedRows();
+    if (!rows.length) {
+      $("#guess-step3-results-container").html("No Step 2 results available");
       return;
     }
-    const cols = Object.keys(data[0]);
-    cols.sort(function (a, b) {
-      if (a === "business_name") return -1;
-      if (b === "business_name") return 1;
-      return 0;
-    });
-    let html = '<table id="guess-contacts-results-table"><thead><tr>';
-    cols.forEach(function (col) {
+    const businessKey = getBusinessNameKey(rows[0]);
+    const columns = [];
+    if (businessKey) {
+      columns.push(businessKey);
+    }
+    if (columns.indexOf("raw_public_emails") === -1) {
+      columns.push("raw_public_emails");
+    }
+    if (columns.indexOf("email_domain") === -1) {
+      columns.push("email_domain");
+    }
+    if (columns.indexOf("raw_contacts") === -1) {
+      columns.push("raw_contacts");
+    }
+    let html = '<table id="guess-step3-results-table"><thead><tr><th>index</th>';
+    columns.forEach(function (col) {
       html += "<th>" + col + "</th>";
     });
     html += "</tr></thead><tbody>";
-    data.forEach(function (row) {
-      html += "<tr>";
-      cols.forEach(function (k) {
-        html += "<td>" + (row[k] || "") + "</td>";
+    rows.forEach(function (row) {
+      html += "<tr><td>" + row.index + "</td>";
+      columns.forEach(function (col) {
+        const value = row[col];
+        html += "<td>" + formatValue(value) + "</td>";
       });
       html += "</tr>";
     });
     html += "</tbody></table>";
-    $("#guess-contacts-container").html(html);
+    $("#guess-step3-results-container").html(html);
+  }
+
+  function runStep3Request(payload, onSuccess, onError) {
+    currentRequest = $.ajax({
+      url: "/generate_contacts/guess/step3/process_single",
+      method: "POST",
+      contentType: "application/json",
+      data: JSON.stringify(payload),
+      success: onSuccess,
+      error: onError,
+    });
+  }
+
+  function handleSuccess(idx, data) {
+    const normalizedRow = data && typeof data === "object" ? data : {};
+    const rawContacts = Object.prototype.hasOwnProperty.call(normalizedRow, "raw_contacts")
+      ? normalizedRow.raw_contacts
+      : normalizedRow.result;
+    step3Results[idx] = { raw_contacts: rawContacts };
+    const step2Data = ensureStep2Results();
+    const existingRow = step2Data[idx] || {};
+    const mergedRow = { ...existingRow, ...normalizedRow, raw_contacts: rawContacts, index: idx };
+    step2Data[idx] = mergedRow;
+    persistStep2Results(step2Data);
+    storeStep3Results();
+    renderCombinedTable();
+  }
+
+  function processRange(start, end, prompt, instructions) {
+    if (end < start) {
+      alert("End index must be greater than or equal to start index");
+      return;
+    }
+    const indexes = [];
+    for (let i = start; i <= end; i += 1) {
+      indexes.push(i);
+    }
+    cancelProcessing = false;
+
+    function processNext(position) {
+      if (cancelProcessing || position >= indexes.length) {
+        return;
+      }
+      const idx = indexes[position];
+      function send(attempt) {
+        runStep3Request(
+          {
+            prompt: prompt,
+            instructions: instructions,
+            row_index: idx,
+          },
+          function (response) {
+            handleSuccess(idx, response);
+            if (!cancelProcessing) {
+              setTimeout(function () {
+                processNext(position + 1);
+              }, 300);
+            }
+          },
+          function (xhr) {
+            console.error("Error processing Step 3 row", idx, xhr.responseText);
+            if (!cancelProcessing) {
+              if (attempt < 1) {
+                setTimeout(function () {
+                  send(attempt + 1);
+                }, 300);
+              } else {
+                setTimeout(function () {
+                  processNext(position + 1);
+                }, 300);
+              }
+            }
+          }
+        );
+      }
+      send(0);
+    }
+
+    processNext(0);
   }
 
   $(document).ready(function () {
-    const saved = localStorage.getItem(CONTACTS_KEY);
-    if (saved) {
+    const savedStep3 = localStorage.getItem(STEP3_RESULTS_KEY);
+    if (savedStep3) {
       try {
-        parsedContacts = JSON.parse(saved);
-        renderContactsTable(parsedContacts);
-      } catch (e) {
-        console.error(e);
+        step3Results = JSON.parse(savedStep3);
+      } catch (err) {
+        console.error("Unable to parse Step 3 results", err);
+        step3Results = {};
       }
     }
-  });
 
-  $("#guess-parse-btn").on("click", function () {
-    const currentStep2Results = ensureStep2Results();
-    if (Object.keys(currentStep2Results).length === 0) {
-      alert("No Step 2 results to parse");
-      return;
+    const defaultInstructions = `You are a sales research assistant.
+
+Given the business name, location, and website, identify every contact who matches the operations leadership profile (e.g., COO, Head of Operations, Director of Operations, Operations Manager, or similar senior roles). For each matching contact, provide their first name, last name, and role.
+
+Return the contacts as a JSON array of arrays in the form [["First", "Last", "Role"], ...]. Only include contacts that match the profile and respond with just the JSON array.`;
+    const savedInstructions = localStorage.getItem(STEP3_INSTRUCTIONS_KEY);
+    if (savedInstructions && savedInstructions.trim() !== "") {
+      $("#guess-step3-instructions").val(savedInstructions);
+    } else {
+      $("#guess-step3-instructions").val(defaultInstructions);
     }
-    $.ajax({
-      url: "/generate_contacts/guess/parse_contacts",
-      method: "POST",
-      contentType: "application/json",
-      data: JSON.stringify({ results: Object.values(currentStep2Results) }),
-      success: function (data) {
-        parsedContacts = parsedContacts.concat(data);
-        renderContactsTable(parsedContacts);
-        localStorage.setItem(CONTACTS_KEY, JSON.stringify(parsedContacts));
-      },
-      error: function (xhr) {
-        alert(xhr.responseText);
-      },
+    $("#guess-step3-instructions").on("input", function () {
+      localStorage.setItem(STEP3_INSTRUCTIONS_KEY, $(this).val());
+    });
+
+    const defaultPrompt = "{business_name} {location} {website}";
+    const savedPrompt = localStorage.getItem(STEP3_PROMPT_KEY);
+    if (savedPrompt && savedPrompt.trim() !== "") {
+      $("#guess-step3-prompt").val(savedPrompt);
+    } else {
+      $("#guess-step3-prompt").val(defaultPrompt);
+    }
+    $("#guess-step3-prompt").on("input", function () {
+      localStorage.setItem(STEP3_PROMPT_KEY, $(this).val());
+    });
+
+    renderCombinedTable();
+
+    $(document).on("guessStep2ResultsUpdated", function () {
+      renderCombinedTable();
+    });
+
+    $("#guess-step3-process-single-btn").on("click", function () {
+      const prompt = $("#guess-step3-prompt").val();
+      const instructions = $("#guess-step3-instructions").val();
+      const rowIndex = parseInt($("#guess-step3-row-index").val(), 10) || 0;
+      cancelProcessing = false;
+      runStep3Request(
+        {
+          prompt: prompt,
+          instructions: instructions,
+          row_index: rowIndex,
+        },
+        function (data) {
+          handleSuccess(rowIndex, data);
+        },
+        function (xhr) {
+          console.error("Error processing Step 3 row", rowIndex, xhr.responseText);
+        }
+      );
+    });
+
+    $("#guess-step3-process-range-btn").on("click", function () {
+      const prompt = $("#guess-step3-prompt").val();
+      const instructions = $("#guess-step3-instructions").val();
+      const start = parseInt($("#guess-step3-start-index").val(), 10) || 0;
+      const end = parseInt($("#guess-step3-end-index").val(), 10) || 0;
+      processRange(start, end, prompt, instructions);
+    });
+
+    $("#guess-step3-cancel").on("click", function () {
+      cancelProcessing = true;
+      if (currentRequest) {
+        currentRequest.abort();
+      }
+    });
+
+    $("#guess-step3-clear").on("click", function () {
+      step3Results = {};
+      localStorage.removeItem(STEP3_RESULTS_KEY);
+      const step2Data = ensureStep2Results();
+      Object.keys(step2Data).forEach(function (idx) {
+        if (step2Data[idx]) {
+          delete step2Data[idx].raw_contacts;
+        }
+      });
+      persistStep2Results(step2Data);
+      renderCombinedTable();
+    });
+
+    $("#guess-step3-copy-results").on("click", function () {
+      copyTableToClipboard("#guess-step3-results-table");
     });
   });
 
-  $("#guess-clear-step3").on("click", function () {
-    $("#guess-contacts-container").empty();
-    parsedContacts = [];
-    localStorage.removeItem(CONTACTS_KEY);
-  });
-
-  $("#guess-copy-step3-results").on("click", function () {
-    copyTableToClipboard("#guess-contacts-results-table");
+  $(window).on("beforeunload", function () {
+    storeStep3Results();
+    const promptValue = $("#guess-step3-prompt").val();
+    const instructionsValue = $("#guess-step3-instructions").val();
+    if (typeof promptValue === "string") {
+      localStorage.setItem(STEP3_PROMPT_KEY, promptValue);
+    }
+    if (typeof instructionsValue === "string") {
+      localStorage.setItem(STEP3_INSTRUCTIONS_KEY, instructionsValue);
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- update the guess-method UI to focus Step 2 on collecting public emails and expose a new domain extraction control
- adjust the guess-method backend to store OpenAI responses in raw_public_emails and raw_contacts columns
- rebuild Step 3 client logic to call the new contact prompt, merge results with Step 2 data, and persist them alongside local storage settings

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d0413465f48333b9ede96363ac0603