### PR TITLE
Update guess method prompts and processing UI

### DIFF
--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -50,6 +50,40 @@
         .guess-step-config h3 {
             margin: 0.5em 0;
         }
+        .guess-process-slider {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25em;
+            min-width: 220px;
+        }
+        .guess-process-slider input[type="range"] {
+            width: 100%;
+        }
+        .guess-process-labels {
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.9em;
+            gap: 0.5em;
+        }
+        .guess-process-labels span {
+            flex: 1;
+            text-align: center;
+            padding: 0.3em 0.4em;
+            border-radius: 0.4em;
+            background-color: #f1f3f4;
+            color: #1a73e8;
+            cursor: pointer;
+            user-select: none;
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+        .guess-process-labels span.active {
+            background-color: #1a73e8;
+            color: #fff;
+            font-weight: bold;
+        }
+        .guess-shared-prompt {
+            margin-top: 1em;
+        }
     </style>
 </head>
 <body>
@@ -130,23 +164,28 @@
             <div id="guess-process-section">
                 <div class="guess-process-mode">
                     <strong>Process:</strong>
-                    <label><input type="radio" name="guess-process-mode" value="both" checked> Steps 2 &amp; 3</label>
-                    <label><input type="radio" name="guess-process-mode" value="step2"> Step 2 only</label>
-                    <label><input type="radio" name="guess-process-mode" value="step3"> Step 3 only</label>
+                    <div class="guess-process-slider">
+                        <input type="range" id="guess-process-slider" min="0" max="2" step="1" value="1">
+                        <div class="guess-process-labels">
+                            <span data-value="step2">Process Step 2</span>
+                            <span data-value="both" class="active">Process Both</span>
+                            <span data-value="step3">Process Step 3</span>
+                        </div>
+                    </div>
                 </div>
                 <div class="guess-step-config">
                     <h3>Step 2 Instructions</h3>
                     <label>Instructions:</label><br>
                     <textarea id="guess-instructions" style="height:80px;"></textarea><br>
+                </div>
+                <div class="guess-shared-prompt">
                     <label>Prompt (use column names in {braces}):</label><br>
-                    <textarea id="guess-prompt" style="height:100px;"></textarea><br>
+                    <textarea id="guess-shared-prompt" style="height:100px;"></textarea><br>
                 </div>
                 <div class="guess-step-config">
                     <h3>Step 3 Instructions</h3>
                     <label>Instructions:</label><br>
                     <textarea id="guess-step3-instructions" style="height:80px;"></textarea><br>
-                    <label>Prompt (use column names in {braces}):</label><br>
-                    <textarea id="guess-step3-prompt" style="height:100px;"></textarea><br>
                 </div>
                 <label>Row index for single run:</label>
                 <input type="number" id="guess-row-index" value="0" min="0"><br>
@@ -157,10 +196,8 @@
                 <button id="guess-process-single-btn">Process Single Row</button>
                 <button id="guess-process-range-btn">Process Range</button>
                 <button type="button" id="guess-extract-domain-btn">Extract Domains</button>
-                <button type="button" id="guess-step3-clear">Clear Contact Results</button>
-                <button type="button" id="guess-step3-copy-results">Copy Results</button>
                 <button type="button" id="guess-cancel-step2">Cancel Processing</button>
-                <button type="button" id="guess-clear-step2">Clear All Results</button>
+                <button type="button" id="guess-clear-step2">Clear Results</button>
             </div>
             <div id="guess-results-container" class="scrollable-output" style="margin-top:1em;"></div>
         </div>

--- a/frontend/js/generate_contacts/guess_method/step1.js
+++ b/frontend/js/generate_contacts/guess_method/step1.js
@@ -69,7 +69,7 @@
 
     $("#guess-tsv-input").val(tsvData);
     $("#guess-instructions").val(setup.savedInstructions);
-    $("#guess-prompt").val(setup.savedPrompt);
+    $("#guess-shared-prompt").val(setup.savedPrompt);
 
     if (tsvData) {
       const formData = new FormData();
@@ -96,7 +96,10 @@
       STORAGE_KEYS.instructions,
       $("#guess-instructions").val()
     );
-    localStorage.setItem(STORAGE_KEYS.prompt, $("#guess-prompt").val());
+    localStorage.setItem(
+      STORAGE_KEYS.prompt,
+      $("#guess-shared-prompt").val()
+    );
     Object.values(LEGACY_STORAGE_KEYS).forEach(function (legacyKey) {
       localStorage.removeItem(legacyKey);
     });
@@ -104,7 +107,7 @@
 
   $(document).ready(function () {
     autoPopulateFromSaved();
-    $("#guess-tsv-input, #guess-instructions, #guess-prompt").on(
+    $("#guess-tsv-input, #guess-instructions, #guess-shared-prompt").on(
       "input",
       autoSave
     );

--- a/frontend/js/generate_contacts/guess_method/step2.js
+++ b/frontend/js/generate_contacts/guess_method/step2.js
@@ -1,16 +1,44 @@
 (function () {
   const RESULTS_KEY = "generate_contacts_guess_step2_results";
-  const STEP2_PROMPT_KEY = "generate_contacts_guess_step2_prompt";
-  const STEP3_PROMPT_KEY = "generate_contacts_guess_step3_prompt";
+  const SHARED_PROMPT_KEY = "generate_contacts_guess_shared_prompt";
   const STEP3_INSTRUCTIONS_KEY = "generate_contacts_guess_step3_instructions";
   const STEP3_RESULTS_KEY = "generate_contacts_guess_step3_results";
   const MODE_STORAGE_KEY = "generate_contacts_guess_process_mode";
+  const LEGACY_PROMPT_KEYS = [
+    "generate_contacts_guess_step2_prompt",
+    "generate_contacts_guess_step3_prompt",
+  ];
 
   const PROCESS_MODES = {
     BOTH: "both",
     STEP2: "step2",
     STEP3: "step3",
   };
+
+  const PROCESS_SLIDER_VALUES = [
+    PROCESS_MODES.STEP2,
+    PROCESS_MODES.BOTH,
+    PROCESS_MODES.STEP3,
+  ];
+
+  function modeForSliderPosition(position) {
+    return PROCESS_SLIDER_VALUES[position] || PROCESS_MODES.BOTH;
+  }
+
+  function sliderPositionForMode(mode) {
+    const index = PROCESS_SLIDER_VALUES.indexOf(mode);
+    if (index === -1) {
+      return PROCESS_SLIDER_VALUES.indexOf(PROCESS_MODES.BOTH);
+    }
+    return index;
+  }
+
+  function updateSliderLabels(mode) {
+    $(".guess-process-labels span").removeClass("active");
+    $(".guess-process-labels span[data-value='" + mode + "']").addClass(
+      "active"
+    );
+  }
 
   function replaceStepResults(nextResults) {
     const normalized = nextResults && typeof nextResults === "object" ? nextResults : {};
@@ -298,73 +326,29 @@
   }
 
   function gatherPrompts() {
+    const sharedPrompt = $("#guess-shared-prompt").val() || "";
     return {
       step2Instructions: $("#guess-instructions").val() || "",
-      step2Prompt: $("#guess-prompt").val() || "",
+      step2Prompt: sharedPrompt,
       step3Instructions: $("#guess-step3-instructions").val() || "",
-      step3Prompt: $("#guess-step3-prompt").val() || "",
+      step3Prompt: sharedPrompt,
     };
   }
 
   function getSelectedMode() {
-    const selected = $(
-      'input[name="guess-process-mode"]:checked'
-    ).val();
-    if (
-      selected === PROCESS_MODES.BOTH ||
-      selected === PROCESS_MODES.STEP2 ||
-      selected === PROCESS_MODES.STEP3
-    ) {
-      return selected;
-    }
-    return PROCESS_MODES.BOTH;
+    const position = parseInt($("#guess-process-slider").val(), 10);
+    return modeForSliderPosition(position);
   }
 
   function setSelectedMode(mode) {
-    const value =
+    const normalized =
       mode === PROCESS_MODES.STEP2 || mode === PROCESS_MODES.STEP3
         ? mode
         : PROCESS_MODES.BOTH;
-    $("input[name='guess-process-mode']").prop("checked", false);
-    $("input[name='guess-process-mode'][value='" + value + "']").prop(
-      "checked",
-      true
-    );
-    localStorage.setItem(MODE_STORAGE_KEY, value);
-  }
-
-  function fallbackCopy(text) {
-    const temp = $("<textarea>");
-    $("body").append(temp);
-    temp.val(text).select();
-    document.execCommand("copy");
-    temp.remove();
-  }
-
-  function copyTableToClipboard(selector) {
-    const table = $(selector);
-    if (table.length === 0) {
-      alert("No data to copy.");
-      return;
-    }
-    const rows = [];
-    table.find("tr").each(function () {
-      const cols = [];
-      $(this)
-        .find("th,td")
-        .each(function () {
-          cols.push($(this).text());
-        });
-      rows.push(cols.join("\t"));
-    });
-    const tsv = rows.join("\n");
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(tsv).catch(function () {
-        fallbackCopy(tsv);
-      });
-    } else {
-      fallbackCopy(tsv);
-    }
+    const sliderValue = sliderPositionForMode(normalized);
+    $("#guess-process-slider").val(sliderValue);
+    updateSliderLabels(normalized);
+    localStorage.setItem(MODE_STORAGE_KEY, normalized);
   }
 
   $("#guess-process-single-btn").on("click", function () {
@@ -418,20 +402,6 @@
     }
   });
 
-  $("#guess-step3-clear").on("click", function () {
-    let modified = false;
-    Object.keys(stepResults).forEach(function (idx) {
-      const row = stepResults[idx];
-      if (row && Object.prototype.hasOwnProperty.call(row, "raw_contacts")) {
-        delete row.raw_contacts;
-        modified = true;
-      }
-    });
-    if (modified) {
-      storeResults();
-    }
-  });
-
   $("#guess-clear-step2").on("click", function () {
     stepResults = replaceStepResults({});
     localStorage.removeItem(RESULTS_KEY);
@@ -440,12 +410,15 @@
     $(document).trigger("guessStep2ResultsUpdated", [stepResults]);
   });
 
-  $("#guess-step3-copy-results").on("click", function () {
-    copyTableToClipboard("#guess-results-table");
+  $("#guess-process-slider").on("input change", function () {
+    const position = parseInt($(this).val(), 10) || 0;
+    const mode = modeForSliderPosition(position);
+    setSelectedMode(mode);
   });
 
-  $("input[name='guess-process-mode']").on("change", function () {
-    setSelectedMode($(this).val());
+  $(".guess-process-labels span").on("click", function () {
+    const mode = $(this).attr("data-value");
+    setSelectedMode(mode);
   });
 
   $(document).on("guessStep2ResultsUpdated", function (event, latest) {
@@ -456,36 +429,51 @@
   });
 
   $(document).ready(function () {
-    const defaultStep2Instructions = `You are a research assistant tasked with locating public-facing email inboxes for a company.
+    const defaultStep2Instructions = `provide 3 publicly available email addresses for the company.
 
-Given the business name, location, and website, find three publicly listed email addresses that a prospect could use to reach the company. Prioritize shared inboxes such as info@, contact@, support@, hello@, or similar addresses that appear on the website or reputable directories.
+ONLY list the emails in a list ['e1@co.com, 'e2@co.com', ...]
 
-Return exactly three email strings in a JSON array. If fewer than three unique emails are available, repeat the best available emails so the array still contains three entries.
-
-Output format example:
-["info@example.com", "support@example.com", "contact@example.com"]
-
-Respond with only the JSON array.`;
+NO NOT PROVIDE ANY OTHER DETAILS OR SUPPLEMENTAL INFORMATION`;
     if (!$("#guess-instructions").val()) {
       $("#guess-instructions").val(defaultStep2Instructions);
     }
 
     const defaultPrompt = "{business_name} {location} {website}";
-    const savedPrompt = localStorage.getItem(STEP2_PROMPT_KEY);
+    const savedPrompt = localStorage.getItem(SHARED_PROMPT_KEY);
     if (savedPrompt && savedPrompt.trim() !== "") {
-      $("#guess-prompt").val(savedPrompt);
+      $("#guess-shared-prompt").val(savedPrompt);
     } else {
-      $("#guess-prompt").val(defaultPrompt);
+      $("#guess-shared-prompt").val(defaultPrompt);
     }
-    $("#guess-prompt").on("input", function () {
-      localStorage.setItem(STEP2_PROMPT_KEY, $(this).val());
+    $("#guess-shared-prompt").on("input", function () {
+      localStorage.setItem(SHARED_PROMPT_KEY, $(this).val());
+    });
+    LEGACY_PROMPT_KEYS.forEach(function (key) {
+      localStorage.removeItem(key);
     });
 
-    const defaultStep3Instructions = `You are a sales research assistant.
+    const defaultStep3Instructions = `You are a contact generation expert for sales.
 
-Given the business name, location, and website, identify every contact who matches the operations leadership profile (e.g., COO, Head of Operations, Director of Operations, Operations Manager, or similar senior roles). For each matching contact, provide their first name, last name, and role.
+For the business provided, find leadership contacts. Prioritize accuracy in your contacts.
 
-Return the contacts as a JSON array of arrays in the form [["First", "Last", "Role"], ...]. Only include contacts that match the profile and respond with just the JSON array.`;
+Required output format must contain:
+- firstname
+- lastname
+- role
+
+⚠️ Do not include company name, emails, or any extra explanation.
+⚠️ Output only the raw JSON.
+
+Example input:
+ABC Company
+
+Example output:
+[
+  ["Andrew", "McRae", "Chief Executive Officer"],
+  ["Jeffrey", "Hasham", "Chief Financial Officer"],
+  ["Charles", "Reichmann", "Co-Founder & Managing Partner"],
+  ["Jarrad", "Segal", "Co-Founder & Managing Partner"]
+]`;
     const savedStep3Instructions = localStorage.getItem(
       STEP3_INSTRUCTIONS_KEY
     );
@@ -496,16 +484,6 @@ Return the contacts as a JSON array of arrays in the form [["First", "Last", "Ro
     }
     $("#guess-step3-instructions").on("input", function () {
       localStorage.setItem(STEP3_INSTRUCTIONS_KEY, $(this).val());
-    });
-
-    const savedStep3Prompt = localStorage.getItem(STEP3_PROMPT_KEY);
-    if (savedStep3Prompt && savedStep3Prompt.trim() !== "") {
-      $("#guess-step3-prompt").val(savedStep3Prompt);
-    } else {
-      $("#guess-step3-prompt").val(defaultPrompt);
-    }
-    $("#guess-step3-prompt").on("input", function () {
-      localStorage.setItem(STEP3_PROMPT_KEY, $(this).val());
     });
 
     const savedMode = localStorage.getItem(MODE_STORAGE_KEY);
@@ -542,13 +520,9 @@ Return the contacts as a JSON array of arrays in the form [["First", "Last", "Ro
   });
 
   $(window).on("beforeunload", function () {
-    const step2PromptValue = $("#guess-prompt").val();
-    if (typeof step2PromptValue === "string") {
-      localStorage.setItem(STEP2_PROMPT_KEY, step2PromptValue);
-    }
-    const step3PromptValue = $("#guess-step3-prompt").val();
-    if (typeof step3PromptValue === "string") {
-      localStorage.setItem(STEP3_PROMPT_KEY, step3PromptValue);
+    const sharedPromptValue = $("#guess-shared-prompt").val();
+    if (typeof sharedPromptValue === "string") {
+      localStorage.setItem(SHARED_PROMPT_KEY, sharedPromptValue);
     }
     const step3InstructionsValue = $("#guess-step3-instructions").val();
     if (typeof step3InstructionsValue === "string") {


### PR DESCRIPTION
## Summary
- replace the guess method radio buttons with a three-position slider and consolidate the prompt textarea between steps
- update the default Step 2 and Step 3 instructions to match the new email and leadership contact guidance
- simplify the processing controls and persist the shared prompt across the guess method scripts

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d08bddb54c8333be373e31acf72b05