### PR TITLE
Add email population support to guess method step 4

### DIFF
--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -319,6 +319,13 @@
 <script src="{{ url_for('static', filename='generate_contacts/guess_method/step1.js') }}"></script>
 <script src="{{ url_for('static', filename='generate_contacts/guess_method/step2.js') }}"></script>
 <script src="{{ url_for('static', filename='generate_contacts/guess_method/step3.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/constants.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/shared.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/contacts.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/columns.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/emails.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/storage.js') }}"></script>
+<script src="{{ url_for('static', filename='generate_contacts/guess_method/step4/ui.js') }}"></script>
 <script src="{{ url_for('static', filename='generate_contacts/guess_method/step4.js') }}"></script>
 </body>
 </html>

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -283,7 +283,9 @@
         <div id="guess-step4" style="margin-top:2em;">
             <h2>STEP 4: Parse Contacts</h2>
             <button id="guess-create-contacts-btn">Create Contacts</button>
+            <button type="button" id="guess-populate-emails-btn">Populate Emails</button>
             <button type="button" id="guess-copy-step4-results">Copy Results</button>
+            <button type="button" id="guess-clear-step4-btn">Clear Contents</button>
             <div id="guess-step4-column-controls">
                 <strong>Columns:</strong>
                 <div id="guess-step4-column-toggle"></div>

--- a/frontend/js/generate_contacts/guess_method/step4.js
+++ b/frontend/js/generate_contacts/guess_method/step4.js
@@ -1,571 +1,23 @@
-(function () {
-  const STEP2_RESULTS_KEY = "generate_contacts_guess_step2_results";
-  const CONTACTS_STORAGE_KEY = "generate_contacts_guess_step4_contacts";
-  const COLUMN_SELECTION_KEY = "generate_contacts_guess_step4_selected_columns";
-  const TABLE_SELECTOR = "#guess-step4-results-table";
-  const COLUMN_CONTROLS_WRAPPER = "#guess-step4-column-controls";
-  const COLUMN_TOGGLE_CONTAINER = "#guess-step4-column-toggle";
-  const POPULATE_EMAILS_BUTTON = "#guess-populate-emails-btn";
-  const CLEAR_STEP4_BUTTON = "#guess-clear-step4-btn";
+(function (window, $) {
+  "use strict";
+
+  const Constants = window.guessStep4Constants;
+  const Shared = window.guessStep4Shared;
+  const Contacts = window.guessStep4Contacts;
+  const Columns = window.guessStep4Columns;
+  const Emails = window.guessStep4Emails;
+  const Storage = window.guessStep4Storage;
+  const UI = window.guessStep4UI;
+
+  const TABLE_CONTAINER = "#guess-step4-container";
 
   let parsedContacts = [];
   let availableColumns = [];
   let selectedColumns = [];
   let columnLabels = {};
 
-  function ensureStep2Results() {
-    if (window.guessStep2Results && typeof window.guessStep2Results === "object") {
-      return window.guessStep2Results;
-    }
-
-    const saved = localStorage.getItem(STEP2_RESULTS_KEY);
-    if (saved) {
-      try {
-        window.guessStep2Results = JSON.parse(saved);
-        return window.guessStep2Results;
-      } catch (err) {
-        console.error("Unable to parse stored Step 2 results", err);
-      }
-    }
-
-    window.guessStep2Results = {};
-    return window.guessStep2Results;
-  }
-
-  function extractBracketedJson(text) {
-    if (typeof text !== "string") {
-      return null;
-    }
-    const match = text.match(/\[\s*\[[\s\S]*?\]\s*\]/);
-    return match ? match[0] : null;
-  }
-
-  function parseRawContacts(raw) {
-    if (!raw && raw !== 0) {
-      return [];
-    }
-
-    if (Array.isArray(raw)) {
-      return raw;
-    }
-
-    if (typeof raw === "object") {
-      if (Array.isArray(raw.contacts)) {
-        return raw.contacts;
-      }
-      return [];
-    }
-
-    if (typeof raw === "string") {
-      const trimmed = raw.trim();
-      if (!trimmed) {
-        return [];
-      }
-
-      const bracketed = extractBracketedJson(trimmed) || trimmed;
-      try {
-        const parsed = JSON.parse(bracketed);
-        if (Array.isArray(parsed)) {
-          return parsed;
-        }
-      } catch (err) {
-        console.warn("Unable to parse raw contacts", err);
-      }
-    }
-
-    return [];
-  }
-
-  function ensureArray(value) {
-    return Array.isArray(value) ? value : [];
-  }
-
-  function cloneRow(row) {
-    return row && typeof row === "object" ? { ...row } : {};
-  }
-
-  function matchesExact(expected) {
-    const normalized = String(expected || "").toLowerCase();
-    return function (column) {
-      return String(column || "").toLowerCase() === normalized;
-    };
-  }
-
-  function inferBusinessNameKey(obj) {
-    if (!obj || typeof obj !== "object") {
-      return null;
-    }
-    if (Object.prototype.hasOwnProperty.call(obj, "business_name")) {
-      return "business_name";
-    }
-    const keys = Object.keys(obj);
-    for (let i = 0; i < keys.length; i += 1) {
-      const key = keys[i];
-      if (key === "index") {
-        continue;
-      }
-      const lower = key.toLowerCase();
-      if (
-        lower === "business name" ||
-        lower === "business_name" ||
-        (lower.includes("business") && lower.includes("name")) ||
-        lower === "company name"
-      ) {
-        return key;
-      }
-    }
-    for (let i = 0; i < keys.length; i += 1) {
-      const key = keys[i];
-      if (key === "index") {
-        continue;
-      }
-      if (key.toLowerCase() === "name") {
-        return key;
-      }
-    }
-    return null;
-  }
-
-  function resolveBusinessNameColumn(rows, columns) {
-    if (!Array.isArray(columns) || !columns.length) {
-      return null;
-    }
-    if (columns.indexOf("business_name") !== -1) {
-      return "business_name";
-    }
-    for (let i = 0; i < rows.length; i += 1) {
-      const row = rows[i];
-      const candidate = inferBusinessNameKey(row);
-      if (candidate && columns.indexOf(candidate) !== -1) {
-        return candidate;
-      }
-    }
-    const fallback = columns.find(function (column) {
-      const lower = String(column || "").toLowerCase();
-      return lower.includes("business") && lower.includes("name");
-    });
-    return fallback || null;
-  }
-
-  function resolveDomainColumn(rows, columns) {
-    if (!Array.isArray(columns) || !columns.length) {
-      return null;
-    }
-    if (columns.indexOf("email_domain") !== -1) {
-      return "email_domain";
-    }
-    const exactDomain = columns.find(function (column) {
-      return String(column || "").toLowerCase() === "domain";
-    });
-    if (exactDomain) {
-      return exactDomain;
-    }
-    const partial = columns.find(function (column) {
-      return String(column || "").toLowerCase().includes("domain");
-    });
-    return partial || null;
-  }
-
-  function resolveWebsiteColumn(rows, columns) {
-    if (!Array.isArray(columns) || !columns.length) {
-      return null;
-    }
-    if (columns.indexOf("website") !== -1) {
-      return "website";
-    }
-    const directMatch = columns.find(function (column) {
-      const lower = String(column || "").toLowerCase();
-      return (
-        lower === "company_website" ||
-        lower === "company website" ||
-        lower === "site" ||
-        lower === "url" ||
-        lower.endsWith("website")
-      );
-    });
-    if (directMatch) {
-      return directMatch;
-    }
-    for (let i = 0; i < rows.length; i += 1) {
-      const row = rows[i];
-      if (!row || typeof row !== "object") {
-        continue;
-      }
-      const keys = Object.keys(row);
-      for (let j = 0; j < keys.length; j += 1) {
-        const key = keys[j];
-        if (String(key || "").toLowerCase() === "website") {
-          return key;
-        }
-      }
-    }
-    return null;
-  }
-
-  function cleanDomainValue(value) {
-    if (!value && value !== 0) {
-      return "";
-    }
-    let domain = String(value).trim();
-    if (!domain) {
-      return "";
-    }
-    domain = domain.replace(/^mailto:/i, "");
-    const atIndex = domain.lastIndexOf("@");
-    if (atIndex !== -1) {
-      domain = domain.slice(atIndex + 1);
-    }
-    domain = domain.replace(/^https?:\/\//i, "");
-    domain = domain.replace(/^www\./i, "");
-    const colonIndex = domain.indexOf(":");
-    if (colonIndex !== -1) {
-      domain = domain.slice(0, colonIndex);
-    }
-    const slashIndex = domain.indexOf("/");
-    if (slashIndex !== -1) {
-      domain = domain.slice(0, slashIndex);
-    }
-    const questionIndex = domain.indexOf("?");
-    if (questionIndex !== -1) {
-      domain = domain.slice(0, questionIndex);
-    }
-    const hashIndex = domain.indexOf("#");
-    if (hashIndex !== -1) {
-      domain = domain.slice(0, hashIndex);
-    }
-    return domain.trim().toLowerCase();
-  }
-
-  function resolveDomainForEmail(row) {
-    if (!row || typeof row !== "object") {
-      return "";
-    }
-    const columns = Object.keys(row);
-    const domainKey = resolveDomainColumn([row], columns);
-    if (domainKey) {
-      const domain = cleanDomainValue(row[domainKey]);
-      if (domain) {
-        return domain;
-      }
-    }
-    const websiteKey = resolveWebsiteColumn([row], columns);
-    if (websiteKey) {
-      const domain = cleanDomainValue(row[websiteKey]);
-      if (domain) {
-        return domain;
-      }
-    }
-    return "";
-  }
-
-  function sanitizeNamePart(value) {
-    if (!value && value !== 0) {
-      return "";
-    }
-    return String(value)
-      .trim()
-      .replace(/[^a-zA-Z0-9]/g, "")
-      .toLowerCase();
-  }
-
-  function buildEmailVariationsForRow(row) {
-    const variations = [];
-    const domain = resolveDomainForEmail(row);
-    if (!domain) {
-      return variations;
-    }
-
-    const first = sanitizeNamePart(
-      row.first_name || row.firstname || row.first || row.firstName
-    );
-    const last = sanitizeNamePart(
-      row.last_name || row.lastname || row.last || row.lastName
-    );
-
-    if (!first) {
-      return variations;
-    }
-
-    const firstInitial = first.charAt(0);
-    const existing = new Set();
-
-    function add(pattern, localPart) {
-      if (!pattern || !localPart) {
-        return;
-      }
-      const email = localPart + "@" + domain;
-      const key = pattern + "::" + email.toLowerCase();
-      if (existing.has(key)) {
-        return;
-      }
-      existing.add(key);
-      variations.push({ pattern: pattern, email: email });
-    }
-
-    if (first && last) {
-      add("First.Last", first + "." + last);
-    }
-    if (firstInitial && last) {
-      add("FirstInitial.Last", firstInitial + "." + last);
-    }
-    add("First", first);
-    if (first && last) {
-      add("FirstLast", first + last);
-    }
-    if (firstInitial && last) {
-      add("FirstInitialLast", firstInitial + last);
-    }
-
-    return variations;
-  }
-
-  function formatColumnLabel(column) {
-    if (!column && column !== 0) {
-      return "";
-    }
-    const words = String(column)
-      .replace(/[_\s]+/g, " ")
-      .trim();
-    if (!words) {
-      return String(column);
-    }
-    if (words.length <= 4 && words === words.toUpperCase()) {
-      return words;
-    }
-    return words.replace(/\b\w/g, function (char) {
-      return char.toUpperCase();
-    });
-  }
-
-  function orderColumns(columns, referenceOrder) {
-    const ordered = [];
-    referenceOrder.forEach(function (column) {
-      if (columns.indexOf(column) !== -1) {
-        ordered.push(column);
-      }
-    });
-    columns.forEach(function (column) {
-      if (referenceOrder.indexOf(column) === -1 && ordered.indexOf(column) === -1) {
-        ordered.push(column);
-      }
-    });
-    return ordered;
-  }
-
-  function findDefaultColumnMatches(rows, columns) {
-    const matches = [];
-    const used = new Set();
-    DEFAULT_COLUMN_SPECS.forEach(function (spec) {
-      let key = null;
-      if (typeof spec.resolve === "function") {
-        key = spec.resolve(rows, columns);
-      }
-      if (!key && typeof spec.match === "function") {
-        key = columns.find(function (column) {
-          if (used.has(column)) {
-            return false;
-          }
-          return spec.match(column);
-        });
-      }
-      if (key && columns.indexOf(key) !== -1 && !used.has(key)) {
-        matches.push({ key: key, spec: spec });
-        used.add(key);
-      }
-    });
-    return matches;
-  }
-
-  function buildColumnLabels(columns, defaultMatches) {
-    const labels = {};
-    const overrides = {};
-    (defaultMatches || []).forEach(function (match) {
-      overrides[match.key] = match.spec.label;
-    });
-    columns.forEach(function (column) {
-      if (Object.prototype.hasOwnProperty.call(overrides, column)) {
-        labels[column] = overrides[column];
-      } else {
-        labels[column] = formatColumnLabel(column);
-      }
-    });
-    return labels;
-  }
-
-  function loadStoredSelectedColumns() {
-    const stored = localStorage.getItem(COLUMN_SELECTION_KEY);
-    if (!stored) {
-      return [];
-    }
-    try {
-      const parsed = JSON.parse(stored);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch (err) {
-      console.error("Unable to load Step 4 column selection", err);
-      return [];
-    }
-  }
-
-  function saveSelectedColumns() {
-    if (!availableColumns.length) {
-      return;
-    }
-    try {
-      localStorage.setItem(COLUMN_SELECTION_KEY, JSON.stringify(selectedColumns));
-    } catch (err) {
-      console.error("Unable to store Step 4 column selection", err);
-    }
-  }
-
-  function collectColumns(rows) {
-    const columnSet = new Set();
-    rows.forEach(function (row) {
-      if (row && typeof row === "object") {
-        Object.keys(row).forEach(function (key) {
-          columnSet.add(key);
-        });
-      }
-    });
-
-    const preferred = [
-      "business_name",
-      "first_name",
-      "last_name",
-      "email",
-      "email_pattern",
-      "role",
-      "email_domain",
-      "domain",
-      "website",
-      "contact_position",
-      "parse_status",
-      "additional_contact_data",
-      "index",
-      "raw_public_emails",
-      "raw_contacts",
-    ];
-
-    const ordered = [];
-    preferred.forEach(function (key) {
-      if (columnSet.has(key)) {
-        ordered.push(key);
-        columnSet.delete(key);
-      }
-    });
-
-    Array.from(columnSet)
-      .sort(function (a, b) {
-        return String(a).localeCompare(String(b));
-      })
-      .forEach(function (key) {
-        ordered.push(key);
-      });
-
-    return ordered;
-  }
-
-  function ensureCanonicalFields(row) {
-    if (!row || typeof row !== "object") {
-      return {};
-    }
-    const normalized = row;
-    if (typeof normalized.business_name === "undefined") {
-      const businessKey = inferBusinessNameKey(normalized);
-      if (businessKey && typeof normalized[businessKey] !== "undefined") {
-        normalized.business_name = normalized[businessKey];
-      }
-    }
-    if (typeof normalized.website === "undefined") {
-      const websiteKey = resolveWebsiteColumn([normalized], Object.keys(normalized));
-      if (websiteKey && typeof normalized[websiteKey] !== "undefined") {
-        normalized.website = normalized[websiteKey];
-      }
-    }
-    return normalized;
-  }
-
-  function normalizeContacts(rows) {
-    if (!Array.isArray(rows)) {
-      return [];
-    }
-    return rows.map(function (row) {
-      return ensureCanonicalFields(cloneRow(row));
-    });
-  }
-
-  const DEFAULT_COLUMN_SPECS = [
-    { id: "business_name", label: "Business Name", resolve: resolveBusinessNameColumn },
-    { id: "first_name", label: "First Name", match: matchesExact("first_name") },
-    { id: "last_name", label: "Last Name", match: matchesExact("last_name") },
-    { id: "email", label: "Email", match: matchesExact("email") },
-    {
-      id: "email_pattern",
-      label: "Email Pattern",
-      match: matchesExact("email_pattern"),
-    },
-    { id: "role", label: "Role", match: matchesExact("role") },
-    { id: "domain", label: "Domain", resolve: resolveDomainColumn },
-    { id: "website", label: "Website", resolve: resolveWebsiteColumn },
-  ];
-
-  function buildContactRows() {
-    const results = ensureStep2Results();
-    const indexes = Object.keys(results).sort(function (a, b) {
-      return parseInt(a, 10) - parseInt(b, 10);
-    });
-
-    const contacts = [];
-
-    indexes.forEach(function (idx) {
-      const row = results[idx] || {};
-      const baseData = ensureCanonicalFields(cloneRow(row));
-      const rawContacts = baseData.raw_contacts;
-      const contactEntries = ensureArray(parseRawContacts(rawContacts));
-
-      if (!contactEntries.length) {
-        const fallback = ensureCanonicalFields(cloneRow(baseData));
-        fallback.first_name = fallback.first_name || "";
-        fallback.last_name = fallback.last_name || "";
-        fallback.role = fallback.role || "";
-        fallback.contact_position = 1;
-        fallback.parse_status =
-          typeof rawContacts === "string" && rawContacts.trim() !== ""
-            ? rawContacts.trim()
-            : "No contacts parsed";
-        contacts.push(fallback);
-        return;
-      }
-
-      contactEntries.forEach(function (entry, position) {
-        const current = ensureCanonicalFields(cloneRow(baseData));
-        if (Array.isArray(entry)) {
-          current.first_name = entry[0] || "";
-          current.last_name = entry[1] || "";
-          current.role = entry[2] || "";
-          if (entry.length > 3) {
-            current.additional_contact_data = JSON.stringify(entry.slice(3));
-          }
-        } else if (entry && typeof entry === "object") {
-          current.first_name = entry.first_name || entry.firstname || "";
-          current.last_name = entry.last_name || entry.lastname || "";
-          current.role = entry.role || entry.title || "";
-          current.additional_contact_data = JSON.stringify(entry);
-        } else {
-          current.first_name = "";
-          current.last_name = "";
-          current.role = "";
-          current.additional_contact_data = JSON.stringify(entry);
-        }
-        current.contact_position = position + 1;
-        contacts.push(current);
-      });
-    });
-
-    return normalizeContacts(contacts);
-  }
-
   function updateAvailableColumns(rows) {
-    const columns = collectColumns(rows);
+    const columns = Columns.collectColumns(rows);
     availableColumns = columns;
     if (!columns.length) {
       selectedColumns = [];
@@ -573,94 +25,29 @@
       return;
     }
 
-    const defaultMatches = findDefaultColumnMatches(rows, columns);
-    columnLabels = buildColumnLabels(columns, defaultMatches);
+    const defaultMatches = Columns.findDefaultColumnMatches(rows, columns);
+    columnLabels = Columns.buildColumnLabels(columns, defaultMatches);
 
-    const storedSelection = loadStoredSelectedColumns().filter(function (column) {
+    const storedSelection = Storage.loadSelectedColumns().filter(function (column) {
       return columns.indexOf(column) !== -1;
     });
 
     if (storedSelection.length) {
-      selectedColumns = orderColumns(storedSelection, columns);
+      selectedColumns = Shared.orderColumns(storedSelection, columns);
     } else {
       const defaults = defaultMatches.map(function (match) {
         return match.key;
       });
       selectedColumns =
         defaults.length > 0
-          ? orderColumns(defaults, columns)
+          ? Shared.orderColumns(defaults, columns)
           : columns.slice(0, Math.min(columns.length, 6));
     }
 
-    saveSelectedColumns();
+    Storage.storeSelectedColumns(selectedColumns);
   }
 
-  function renderContactsTable(rows) {
-    const container = $("#guess-step4-container");
-    if (!selectedColumns.length) {
-      container.html('<div class="guess-step4-empty">Select at least one column to view results.</div>');
-      return;
-    }
-
-    let html = '<table id="guess-step4-results-table"><thead><tr>';
-    selectedColumns.forEach(function (column) {
-      const heading = columnLabels[column] || formatColumnLabel(column);
-      html += "<th>" + heading + "</th>";
-    });
-    html += "</tr></thead><tbody>";
-
-    rows.forEach(function (row) {
-      html += "<tr>";
-      selectedColumns.forEach(function (column) {
-        const value = row[column];
-        html += "<td>" + (value !== undefined && value !== null ? value : "") + "</td>";
-      });
-      html += "</tr>";
-    });
-
-    html += "</tbody></table>";
-    container.html(html);
-  }
-
-  function renderColumnControls() {
-    const wrapper = $(COLUMN_CONTROLS_WRAPPER);
-    const container = $(COLUMN_TOGGLE_CONTAINER);
-    container.empty();
-
-    if (!availableColumns.length) {
-      wrapper.hide();
-      return;
-    }
-
-    wrapper.css("display", "flex");
-
-    availableColumns.forEach(function (column) {
-      const isChecked = selectedColumns.indexOf(column) !== -1;
-      const labelText = columnLabels[column] || formatColumnLabel(column);
-      const safeId = "guess-step4-col-" + String(column).replace(/[^a-zA-Z0-9]+/g, "-").toLowerCase();
-
-      const $label = $("<label>").addClass("guess-step4-toggle");
-      const $input = $("<input>")
-        .attr("type", "checkbox")
-        .attr("id", safeId)
-        .attr("data-column", column)
-        .prop("checked", isChecked);
-      const $slider = $("<span>").addClass("guess-step4-toggle-slider").attr("aria-hidden", "true");
-      const $text = $("<span>").addClass("guess-step4-toggle-label").text(labelText);
-
-      $input.on("change", function () {
-        handleColumnToggleChange(this);
-      });
-
-      $label.append($input, $slider, $text);
-      container.append($label);
-    });
-  }
-
-  function handleColumnToggleChange(input) {
-    const column = $(input).attr("data-column");
-    const isChecked = $(input).is(":checked");
-
+  function handleColumnToggle(column, isChecked) {
     if (!column) {
       return;
     }
@@ -675,9 +62,9 @@
       });
     }
 
-    selectedColumns = orderColumns(selectedColumns, availableColumns);
-    saveSelectedColumns();
-    renderContactsTable(parsedContacts);
+    selectedColumns = Shared.orderColumns(selectedColumns, availableColumns);
+    Storage.storeSelectedColumns(selectedColumns);
+    UI.renderContactsTable(TABLE_CONTAINER, parsedContacts, selectedColumns, columnLabels);
   }
 
   function refreshContactsDisplay() {
@@ -685,119 +72,40 @@
       availableColumns = [];
       selectedColumns = [];
       columnLabels = {};
-      $(COLUMN_TOGGLE_CONTAINER).empty();
-      $(COLUMN_CONTROLS_WRAPPER).hide();
-      $("#guess-step4-container").html("No contacts available");
+      $(Constants.COLUMN_TOGGLE_CONTAINER).empty();
+      $(Constants.COLUMN_CONTROLS_WRAPPER).hide();
+      UI.showEmptyState("No contacts available");
       return;
     }
 
-    parsedContacts = normalizeContacts(parsedContacts);
+    parsedContacts = Contacts.normalizeContacts(parsedContacts);
     updateAvailableColumns(parsedContacts);
-    renderColumnControls();
-    renderContactsTable(parsedContacts);
+    UI.renderColumnControls(availableColumns, selectedColumns, columnLabels, handleColumnToggle);
+    UI.renderContactsTable(TABLE_CONTAINER, parsedContacts, selectedColumns, columnLabels);
   }
 
-  function copyTableToClipboard(selector) {
-    const table = $(selector);
-    if (!table.length) {
-      alert("No data to copy.");
-      return;
-    }
-
-    const rows = [];
-    table.find("tr").each(function () {
-      const cols = [];
-      $(this)
-        .find("th,td")
-        .each(function () {
-          cols.push($(this).text());
-        });
-      rows.push(cols.join("\t"));
-    });
-
-    const tsv = rows.join("\n");
-
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(tsv).catch(function () {
-        fallbackCopy(tsv);
-      });
-    } else {
-      fallbackCopy(tsv);
-    }
-  }
-
-  function fallbackCopy(text) {
-    const temp = $("<textarea>");
-    $("body").append(temp);
-    temp.val(text).select();
-    document.execCommand("copy");
-    temp.remove();
-  }
-
-  function storeContacts(rows) {
-    window.guessStep4Contacts = rows;
-    try {
-      localStorage.setItem(CONTACTS_STORAGE_KEY, JSON.stringify(rows));
-    } catch (err) {
-      console.error("Unable to store Step 4 contacts", err);
-    }
-  }
-
-  function loadStoredContacts() {
-    const saved = localStorage.getItem(CONTACTS_STORAGE_KEY);
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        parsedContacts = normalizeContacts(parsed);
-        window.guessStep4Contacts = parsedContacts;
-      } catch (err) {
-        console.error("Unable to load stored Step 4 contacts", err);
-        parsedContacts = [];
-      }
-    }
+  function createContacts() {
+    parsedContacts = Contacts.buildContactRows();
+    parsedContacts = Contacts.normalizeContacts(parsedContacts);
+    Storage.storeContacts(parsedContacts);
     refreshContactsDisplay();
   }
 
-  function populateEmailsForContacts() {
+  function populateEmails() {
     if (!Array.isArray(parsedContacts) || !parsedContacts.length) {
       alert("No contacts available to populate. Please create contacts first.");
       return;
     }
 
-    const baseRows = parsedContacts
-      .filter(function (row) {
-        return row && typeof row === "object" && !row.email_pattern;
-      })
-      .map(function (row) {
-        return ensureCanonicalFields(cloneRow(row));
-      });
+    const result = Emails.generateEmailRows(parsedContacts);
 
-    if (!baseRows.length) {
+    if (!result.baseRows.length) {
       alert("No base contacts are available. Please create contacts first.");
       return;
     }
 
-    const existingGenerated = parsedContacts.filter(function (row) {
-      return row && typeof row === "object" && row.email_pattern;
-    });
-
-    const updatedRows = [];
-    let generatedCount = 0;
-
-    baseRows.forEach(function (row) {
-      updatedRows.push(row);
-      const variations = buildEmailVariationsForRow(row);
-      variations.forEach(function (variation) {
-        const emailRow = ensureCanonicalFields(cloneRow(row));
-        emailRow.email = variation.email;
-        emailRow.email_pattern = variation.pattern;
-        updatedRows.push(emailRow);
-        generatedCount += 1;
-      });
-    });
-
-    if (!generatedCount) {
-      if (existingGenerated.length) {
+    if (!result.generatedCount) {
+      if (result.existingGenerated.length) {
         alert("Email variations are already populated for the available contacts.");
         refreshContactsDisplay();
         return;
@@ -805,14 +113,14 @@
       alert(
         "Unable to generate email variations. Ensure contacts include first name, last name, and domain details."
       );
-      parsedContacts = normalizeContacts(baseRows);
-      storeContacts(parsedContacts);
+      parsedContacts = Contacts.normalizeContacts(result.baseRows);
+      Storage.storeContacts(parsedContacts);
       refreshContactsDisplay();
       return;
     }
 
-    parsedContacts = normalizeContacts(updatedRows);
-    storeContacts(parsedContacts);
+    parsedContacts = result.updatedRows;
+    Storage.storeContacts(parsedContacts);
     refreshContactsDisplay();
   }
 
@@ -821,38 +129,26 @@
     availableColumns = [];
     selectedColumns = [];
     columnLabels = {};
-    window.guessStep4Contacts = [];
-    try {
-      localStorage.removeItem(CONTACTS_STORAGE_KEY);
-    } catch (err) {
-      console.error("Unable to clear stored Step 4 contacts", err);
-    }
-    try {
-      localStorage.removeItem(COLUMN_SELECTION_KEY);
-    } catch (err) {
-      console.error("Unable to clear Step 4 column selection", err);
+    Storage.clearContacts();
+    Storage.clearSelectedColumns();
+    UI.showEmptyState("No contacts available");
+    $(Constants.COLUMN_TOGGLE_CONTAINER).empty();
+    $(Constants.COLUMN_CONTROLS_WRAPPER).hide();
+  }
+
+  function loadStoredContacts() {
+    const saved = Storage.loadContacts();
+    if (saved && Array.isArray(saved)) {
+      parsedContacts = Contacts.normalizeContacts(saved);
+    } else {
+      parsedContacts = [];
     }
     refreshContactsDisplay();
   }
 
-  $("#guess-create-contacts-btn").on("click", function () {
-    const contacts = buildContactRows();
-    parsedContacts = contacts;
-    storeContacts(parsedContacts);
-    refreshContactsDisplay();
-  });
-
-  $(POPULATE_EMAILS_BUTTON).on("click", function () {
-    populateEmailsForContacts();
-  });
-
-  $("#guess-copy-step4-results").on("click", function () {
-    copyTableToClipboard(TABLE_SELECTOR);
-  });
-
-  $(CLEAR_STEP4_BUTTON).on("click", function () {
-    clearStep4Results();
-  });
+  function handleCopy() {
+    UI.copyTableToClipboard(Constants.TABLE_SELECTOR);
+  }
 
   $(document).on("guessStep2ResultsUpdated", function (event, results) {
     if (results && typeof results === "object") {
@@ -860,7 +156,11 @@
     }
   });
 
-  $(document).ready(function () {
+  $(function () {
+    $("#guess-create-contacts-btn").on("click", createContacts);
+    $(Constants.POPULATE_EMAILS_BUTTON).on("click", populateEmails);
+    $("#guess-copy-step4-results").on("click", handleCopy);
+    $(Constants.CLEAR_STEP4_BUTTON).on("click", clearStep4Results);
     loadStoredContacts();
   });
-})();
+})(window, window.jQuery);

--- a/frontend/js/generate_contacts/guess_method/step4/columns.js
+++ b/frontend/js/generate_contacts/guess_method/step4/columns.js
@@ -1,0 +1,118 @@
+(function (window) {
+  "use strict";
+
+  const Shared = window.guessStep4Shared;
+
+  const DEFAULT_COLUMN_SPECS = [
+    {
+      id: "business_name",
+      label: "Business Name",
+      resolve: Shared.resolveBusinessNameColumn,
+    },
+    { id: "first_name", label: "First Name", match: Shared.matchesExact("first_name") },
+    { id: "last_name", label: "Last Name", match: Shared.matchesExact("last_name") },
+    { id: "email", label: "Email", match: Shared.matchesExact("email") },
+    {
+      id: "email_pattern",
+      label: "Email Pattern",
+      match: Shared.matchesExact("email_pattern"),
+    },
+    { id: "role", label: "Role", match: Shared.matchesExact("role") },
+    { id: "domain", label: "Domain", resolve: Shared.resolveDomainColumn },
+    { id: "website", label: "Website", resolve: Shared.resolveWebsiteColumn },
+  ];
+
+  function collectColumns(rows) {
+    const columnSet = new Set();
+    rows.forEach(function (row) {
+      if (row && typeof row === "object") {
+        Object.keys(row).forEach(function (key) {
+          columnSet.add(key);
+        });
+      }
+    });
+
+    const preferred = [
+      "business_name",
+      "first_name",
+      "last_name",
+      "email",
+      "email_pattern",
+      "role",
+      "email_domain",
+      "domain",
+      "website",
+      "contact_position",
+      "parse_status",
+      "additional_contact_data",
+      "index",
+      "raw_public_emails",
+      "raw_contacts",
+    ];
+
+    const ordered = [];
+    preferred.forEach(function (key) {
+      if (columnSet.has(key)) {
+        ordered.push(key);
+        columnSet.delete(key);
+      }
+    });
+
+    Array.from(columnSet)
+      .sort(function (a, b) {
+        return String(a).localeCompare(String(b));
+      })
+      .forEach(function (key) {
+        ordered.push(key);
+      });
+
+    return ordered;
+  }
+
+  function findDefaultColumnMatches(rows, columns) {
+    const matches = [];
+    const used = new Set();
+    DEFAULT_COLUMN_SPECS.forEach(function (spec) {
+      let key = null;
+      if (typeof spec.resolve === "function") {
+        key = spec.resolve(rows, columns);
+      }
+      if (!key && typeof spec.match === "function") {
+        key = columns.find(function (column) {
+          if (used.has(column)) {
+            return false;
+          }
+          return spec.match(column);
+        });
+      }
+      if (key && columns.indexOf(key) !== -1 && !used.has(key)) {
+        matches.push({ key: key, spec: spec });
+        used.add(key);
+      }
+    });
+    return matches;
+  }
+
+  function buildColumnLabels(columns, defaultMatches) {
+    const labels = {};
+    const overrides = {};
+    (defaultMatches || []).forEach(function (match) {
+      overrides[match.key] = match.spec.label;
+    });
+    columns.forEach(function (column) {
+      if (Object.prototype.hasOwnProperty.call(overrides, column)) {
+        labels[column] = overrides[column];
+      } else {
+        labels[column] = Shared.formatColumnLabel(column);
+      }
+    });
+    return labels;
+  }
+
+  window.guessStep4Columns = {
+    DEFAULT_COLUMN_SPECS: DEFAULT_COLUMN_SPECS,
+    collectColumns: collectColumns,
+    findDefaultColumnMatches: findDefaultColumnMatches,
+    buildColumnLabels: buildColumnLabels,
+  };
+})(window);

--- a/frontend/js/generate_contacts/guess_method/step4/constants.js
+++ b/frontend/js/generate_contacts/guess_method/step4/constants.js
@@ -1,0 +1,14 @@
+(function (window) {
+  "use strict";
+
+  window.guessStep4Constants = {
+    STEP2_RESULTS_KEY: "generate_contacts_guess_step2_results",
+    CONTACTS_STORAGE_KEY: "generate_contacts_guess_step4_contacts",
+    COLUMN_SELECTION_KEY: "generate_contacts_guess_step4_selected_columns",
+    TABLE_SELECTOR: "#guess-step4-results-table",
+    COLUMN_CONTROLS_WRAPPER: "#guess-step4-column-controls",
+    COLUMN_TOGGLE_CONTAINER: "#guess-step4-column-toggle",
+    POPULATE_EMAILS_BUTTON: "#guess-populate-emails-btn",
+    CLEAR_STEP4_BUTTON: "#guess-clear-step4-btn",
+  };
+})(window);

--- a/frontend/js/generate_contacts/guess_method/step4/contacts.js
+++ b/frontend/js/generate_contacts/guess_method/step4/contacts.js
@@ -1,0 +1,140 @@
+(function (window) {
+  "use strict";
+
+  const Shared = window.guessStep4Shared;
+  const Constants = window.guessStep4Constants;
+
+  function ensureStep2Results() {
+    if (window.guessStep2Results && typeof window.guessStep2Results === "object") {
+      return window.guessStep2Results;
+    }
+
+    const saved = localStorage.getItem(Constants.STEP2_RESULTS_KEY);
+    if (saved) {
+      try {
+        window.guessStep2Results = JSON.parse(saved);
+        return window.guessStep2Results;
+      } catch (err) {
+        console.error("Unable to parse stored Step 2 results", err);
+      }
+    }
+
+    window.guessStep2Results = {};
+    return window.guessStep2Results;
+  }
+
+  function ensureCanonicalFields(row) {
+    if (!row || typeof row !== "object") {
+      return {};
+    }
+    const normalized = row;
+    if (typeof normalized.business_name === "undefined") {
+      const businessKey = Shared.inferBusinessNameKey(normalized);
+      if (businessKey && typeof normalized[businessKey] !== "undefined") {
+        normalized.business_name = normalized[businessKey];
+      }
+    }
+    if (typeof normalized.website === "undefined") {
+      const websiteKey = Shared.resolveWebsiteColumn([normalized], Object.keys(normalized));
+      if (websiteKey && typeof normalized[websiteKey] !== "undefined") {
+        normalized.website = normalized[websiteKey];
+      }
+    }
+    return normalized;
+  }
+
+  function normalizeContacts(rows) {
+    if (!Array.isArray(rows)) {
+      return [];
+    }
+    return rows.map(function (row) {
+      return ensureCanonicalFields(Shared.cloneRow(row));
+    });
+  }
+
+  function resolveDomainForEmail(row) {
+    if (!row || typeof row !== "object") {
+      return "";
+    }
+    const columns = Object.keys(row);
+    const domainKey = Shared.resolveDomainColumn([row], columns);
+    if (domainKey) {
+      const domain = Shared.cleanDomainValue(row[domainKey]);
+      if (domain) {
+        return domain;
+      }
+    }
+    const websiteKey = Shared.resolveWebsiteColumn([row], columns);
+    if (websiteKey) {
+      const domain = Shared.cleanDomainValue(row[websiteKey]);
+      if (domain) {
+        return domain;
+      }
+    }
+    return "";
+  }
+
+  function buildContactRows() {
+    const results = ensureStep2Results();
+    const indexes = Object.keys(results).sort(function (a, b) {
+      return parseInt(a, 10) - parseInt(b, 10);
+    });
+
+    const contacts = [];
+
+    indexes.forEach(function (idx) {
+      const row = results[idx] || {};
+      const baseData = ensureCanonicalFields(Shared.cloneRow(row));
+      const rawContacts = baseData.raw_contacts;
+      const contactEntries = Shared.ensureArray(Shared.parseRawContacts(rawContacts));
+
+      if (!contactEntries.length) {
+        const fallback = ensureCanonicalFields(Shared.cloneRow(baseData));
+        fallback.first_name = fallback.first_name || "";
+        fallback.last_name = fallback.last_name || "";
+        fallback.role = fallback.role || "";
+        fallback.contact_position = 1;
+        fallback.parse_status =
+          typeof rawContacts === "string" && rawContacts.trim() !== ""
+            ? rawContacts.trim()
+            : "No contacts parsed";
+        contacts.push(fallback);
+        return;
+      }
+
+      contactEntries.forEach(function (entry, position) {
+        const current = ensureCanonicalFields(Shared.cloneRow(baseData));
+        if (Array.isArray(entry)) {
+          current.first_name = entry[0] || "";
+          current.last_name = entry[1] || "";
+          current.role = entry[2] || "";
+          if (entry.length > 3) {
+            current.additional_contact_data = JSON.stringify(entry.slice(3));
+          }
+        } else if (entry && typeof entry === "object") {
+          current.first_name = entry.first_name || entry.firstname || "";
+          current.last_name = entry.last_name || entry.lastname || "";
+          current.role = entry.role || entry.title || "";
+          current.additional_contact_data = JSON.stringify(entry);
+        } else {
+          current.first_name = "";
+          current.last_name = "";
+          current.role = "";
+          current.additional_contact_data = JSON.stringify(entry);
+        }
+        current.contact_position = position + 1;
+        contacts.push(current);
+      });
+    });
+
+    return normalizeContacts(contacts);
+  }
+
+  window.guessStep4Contacts = {
+    ensureStep2Results: ensureStep2Results,
+    ensureCanonicalFields: ensureCanonicalFields,
+    normalizeContacts: normalizeContacts,
+    resolveDomainForEmail: resolveDomainForEmail,
+    buildContactRows: buildContactRows,
+  };
+})(window);

--- a/frontend/js/generate_contacts/guess_method/step4/emails.js
+++ b/frontend/js/generate_contacts/guess_method/step4/emails.js
@@ -74,7 +74,6 @@
     let generatedCount = 0;
 
     baseRows.forEach(function (row) {
-      updatedRows.push(row);
       const variations = buildEmailVariationsForRow(row);
       variations.forEach(function (variation) {
         const emailRow = Contacts.ensureCanonicalFields(Shared.cloneRow(row));

--- a/frontend/js/generate_contacts/guess_method/step4/emails.js
+++ b/frontend/js/generate_contacts/guess_method/step4/emails.js
@@ -1,0 +1,100 @@
+(function (window) {
+  "use strict";
+
+  const Shared = window.guessStep4Shared;
+  const Contacts = window.guessStep4Contacts;
+
+  function buildEmailVariationsForRow(row) {
+    const variations = [];
+    const domain = Contacts.resolveDomainForEmail(row);
+    if (!domain) {
+      return variations;
+    }
+
+    const first = Shared.sanitizeNamePart(
+      row.first_name || row.firstname || row.first || row.firstName
+    );
+    const last = Shared.sanitizeNamePart(
+      row.last_name || row.lastname || row.last || row.lastName
+    );
+
+    if (!first) {
+      return variations;
+    }
+
+    const firstInitial = first.charAt(0);
+    const existing = new Set();
+
+    function add(pattern, localPart) {
+      if (!pattern || !localPart) {
+        return;
+      }
+      const email = localPart + "@" + domain;
+      const key = pattern + "::" + email.toLowerCase();
+      if (existing.has(key)) {
+        return;
+      }
+      existing.add(key);
+      variations.push({ pattern: pattern, email: email });
+    }
+
+    if (first && last) {
+      add("First.Last", first + "." + last);
+    }
+    if (firstInitial && last) {
+      add("FirstInitial.Last", firstInitial + "." + last);
+    }
+    add("First", first);
+    if (first && last) {
+      add("FirstLast", first + last);
+    }
+    if (firstInitial && last) {
+      add("FirstInitialLast", firstInitial + last);
+    }
+
+    return variations;
+  }
+
+  function generateEmailRows(parsedContacts) {
+    const baseRows = [];
+    const existingGenerated = [];
+
+    (Array.isArray(parsedContacts) ? parsedContacts : []).forEach(function (row) {
+      if (!row || typeof row !== "object") {
+        return;
+      }
+      if (row.email_pattern) {
+        existingGenerated.push(row);
+        return;
+      }
+      baseRows.push(Contacts.ensureCanonicalFields(Shared.cloneRow(row)));
+    });
+
+    const updatedRows = [];
+    let generatedCount = 0;
+
+    baseRows.forEach(function (row) {
+      updatedRows.push(row);
+      const variations = buildEmailVariationsForRow(row);
+      variations.forEach(function (variation) {
+        const emailRow = Contacts.ensureCanonicalFields(Shared.cloneRow(row));
+        emailRow.email = variation.email;
+        emailRow.email_pattern = variation.pattern;
+        updatedRows.push(emailRow);
+        generatedCount += 1;
+      });
+    });
+
+    return {
+      baseRows: baseRows,
+      existingGenerated: existingGenerated,
+      generatedCount: generatedCount,
+      updatedRows: Contacts.normalizeContacts(updatedRows),
+    };
+  }
+
+  window.guessStep4Emails = {
+    buildEmailVariationsForRow: buildEmailVariationsForRow,
+    generateEmailRows: generateEmailRows,
+  };
+})(window);

--- a/frontend/js/generate_contacts/guess_method/step4/shared.js
+++ b/frontend/js/generate_contacts/guess_method/step4/shared.js
@@ -1,0 +1,266 @@
+(function (window) {
+  "use strict";
+
+  function ensureArray(value) {
+    return Array.isArray(value) ? value : [];
+  }
+
+  function cloneRow(row) {
+    return row && typeof row === "object" ? { ...row } : {};
+  }
+
+  function extractBracketedJson(text) {
+    if (typeof text !== "string") {
+      return null;
+    }
+    const match = text.match(/\[\s*\[[\s\S]*?\]\s*\]/);
+    return match ? match[0] : null;
+  }
+
+  function parseRawContacts(raw) {
+    if (!raw && raw !== 0) {
+      return [];
+    }
+
+    if (Array.isArray(raw)) {
+      return raw;
+    }
+
+    if (typeof raw === "object") {
+      if (Array.isArray(raw.contacts)) {
+        return raw.contacts;
+      }
+      return [];
+    }
+
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        return [];
+      }
+
+      const bracketed = extractBracketedJson(trimmed) || trimmed;
+      try {
+        const parsed = JSON.parse(bracketed);
+        if (Array.isArray(parsed)) {
+          return parsed;
+        }
+      } catch (err) {
+        console.warn("Unable to parse raw contacts", err);
+      }
+    }
+
+    return [];
+  }
+
+  function matchesExact(expected) {
+    const normalized = String(expected || "").toLowerCase();
+    return function (column) {
+      return String(column || "").toLowerCase() === normalized;
+    };
+  }
+
+  function formatColumnLabel(column) {
+    if (!column && column !== 0) {
+      return "";
+    }
+    const words = String(column)
+      .replace(/[_\s]+/g, " ")
+      .trim();
+    if (!words) {
+      return String(column);
+    }
+    if (words.length <= 4 && words === words.toUpperCase()) {
+      return words;
+    }
+    return words.replace(/\b\w/g, function (char) {
+      return char.toUpperCase();
+    });
+  }
+
+  function orderColumns(columns, referenceOrder) {
+    const ordered = [];
+    referenceOrder.forEach(function (column) {
+      if (columns.indexOf(column) !== -1) {
+        ordered.push(column);
+      }
+    });
+    columns.forEach(function (column) {
+      if (referenceOrder.indexOf(column) === -1 && ordered.indexOf(column) === -1) {
+        ordered.push(column);
+      }
+    });
+    return ordered;
+  }
+
+  function sanitizeNamePart(value) {
+    if (!value && value !== 0) {
+      return "";
+    }
+    return String(value)
+      .trim()
+      .replace(/[^a-zA-Z0-9]/g, "")
+      .toLowerCase();
+  }
+
+  function cleanDomainValue(value) {
+    if (!value && value !== 0) {
+      return "";
+    }
+    let domain = String(value).trim();
+    if (!domain) {
+      return "";
+    }
+    domain = domain.replace(/^mailto:/i, "");
+    const atIndex = domain.lastIndexOf("@");
+    if (atIndex !== -1) {
+      domain = domain.slice(atIndex + 1);
+    }
+    domain = domain.replace(/^https?:\/\//i, "");
+    domain = domain.replace(/^www\./i, "");
+    const colonIndex = domain.indexOf(":");
+    if (colonIndex !== -1) {
+      domain = domain.slice(0, colonIndex);
+    }
+    const slashIndex = domain.indexOf("/");
+    if (slashIndex !== -1) {
+      domain = domain.slice(0, slashIndex);
+    }
+    const questionIndex = domain.indexOf("?");
+    if (questionIndex !== -1) {
+      domain = domain.slice(0, questionIndex);
+    }
+    const hashIndex = domain.indexOf("#");
+    if (hashIndex !== -1) {
+      domain = domain.slice(0, hashIndex);
+    }
+    return domain.trim().toLowerCase();
+  }
+
+  function inferBusinessNameKey(obj) {
+    if (!obj || typeof obj !== "object") {
+      return null;
+    }
+    if (Object.prototype.hasOwnProperty.call(obj, "business_name")) {
+      return "business_name";
+    }
+    const keys = Object.keys(obj);
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      if (key === "index") {
+        continue;
+      }
+      const lower = key.toLowerCase();
+      if (
+        lower === "business name" ||
+        lower === "business_name" ||
+        (lower.includes("business") && lower.includes("name")) ||
+        lower === "company name"
+      ) {
+        return key;
+      }
+    }
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      if (key === "index") {
+        continue;
+      }
+      if (key.toLowerCase() === "name") {
+        return key;
+      }
+    }
+    return null;
+  }
+
+  function resolveBusinessNameColumn(rows, columns) {
+    if (!Array.isArray(columns) || !columns.length) {
+      return null;
+    }
+    if (columns.indexOf("business_name") !== -1) {
+      return "business_name";
+    }
+    for (let i = 0; i < rows.length; i += 1) {
+      const row = rows[i];
+      const candidate = inferBusinessNameKey(row);
+      if (candidate && columns.indexOf(candidate) !== -1) {
+        return candidate;
+      }
+    }
+    const fallback = columns.find(function (column) {
+      const lower = String(column || "").toLowerCase();
+      return lower.includes("business") && lower.includes("name");
+    });
+    return fallback || null;
+  }
+
+  function resolveDomainColumn(rows, columns) {
+    if (!Array.isArray(columns) || !columns.length) {
+      return null;
+    }
+    if (columns.indexOf("email_domain") !== -1) {
+      return "email_domain";
+    }
+    const exactDomain = columns.find(function (column) {
+      return String(column || "").toLowerCase() === "domain";
+    });
+    if (exactDomain) {
+      return exactDomain;
+    }
+    const partial = columns.find(function (column) {
+      return String(column || "").toLowerCase().includes("domain");
+    });
+    return partial || null;
+  }
+
+  function resolveWebsiteColumn(rows, columns) {
+    if (!Array.isArray(columns) || !columns.length) {
+      return null;
+    }
+    if (columns.indexOf("website") !== -1) {
+      return "website";
+    }
+    const directMatch = columns.find(function (column) {
+      const lower = String(column || "").toLowerCase();
+      return (
+        lower === "company_website" ||
+        lower === "company website" ||
+        lower === "site" ||
+        lower === "url" ||
+        lower.endsWith("website")
+      );
+    });
+    if (directMatch) {
+      return directMatch;
+    }
+    for (let i = 0; i < rows.length; i += 1) {
+      const row = rows[i];
+      if (!row || typeof row !== "object") {
+        continue;
+      }
+      const keys = Object.keys(row);
+      for (let j = 0; j < keys.length; j += 1) {
+        const key = keys[j];
+        if (String(key || "").toLowerCase() === "website") {
+          return key;
+        }
+      }
+    }
+    return null;
+  }
+
+  window.guessStep4Shared = {
+    ensureArray: ensureArray,
+    cloneRow: cloneRow,
+    extractBracketedJson: extractBracketedJson,
+    parseRawContacts: parseRawContacts,
+    matchesExact: matchesExact,
+    formatColumnLabel: formatColumnLabel,
+    orderColumns: orderColumns,
+    sanitizeNamePart: sanitizeNamePart,
+    cleanDomainValue: cleanDomainValue,
+    inferBusinessNameKey: inferBusinessNameKey,
+    resolveBusinessNameColumn: resolveBusinessNameColumn,
+    resolveDomainColumn: resolveDomainColumn,
+    resolveWebsiteColumn: resolveWebsiteColumn,
+  };
+})(window);

--- a/frontend/js/generate_contacts/guess_method/step4/storage.js
+++ b/frontend/js/generate_contacts/guess_method/step4/storage.js
@@ -1,0 +1,80 @@
+(function (window) {
+  "use strict";
+
+  const Constants = window.guessStep4Constants;
+
+  function storeContacts(rows) {
+    window.guessStep4ContactsData = rows;
+    try {
+      localStorage.setItem(Constants.CONTACTS_STORAGE_KEY, JSON.stringify(rows));
+    } catch (err) {
+      console.error("Unable to store Step 4 contacts", err);
+    }
+  }
+
+  function loadContacts() {
+    const saved = localStorage.getItem(Constants.CONTACTS_STORAGE_KEY);
+    if (!saved) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(saved);
+      window.guessStep4ContactsData = parsed;
+      return parsed;
+    } catch (err) {
+      console.error("Unable to load stored Step 4 contacts", err);
+      return null;
+    }
+  }
+
+  function clearContacts() {
+    window.guessStep4ContactsData = [];
+    try {
+      localStorage.removeItem(Constants.CONTACTS_STORAGE_KEY);
+    } catch (err) {
+      console.error("Unable to clear stored Step 4 contacts", err);
+    }
+  }
+
+  function storeSelectedColumns(columns) {
+    if (!Array.isArray(columns)) {
+      return;
+    }
+    try {
+      localStorage.setItem(Constants.COLUMN_SELECTION_KEY, JSON.stringify(columns));
+    } catch (err) {
+      console.error("Unable to store Step 4 column selection", err);
+    }
+  }
+
+  function loadSelectedColumns() {
+    const stored = localStorage.getItem(Constants.COLUMN_SELECTION_KEY);
+    if (!stored) {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(stored);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (err) {
+      console.error("Unable to load Step 4 column selection", err);
+      return [];
+    }
+  }
+
+  function clearSelectedColumns() {
+    try {
+      localStorage.removeItem(Constants.COLUMN_SELECTION_KEY);
+    } catch (err) {
+      console.error("Unable to clear Step 4 column selection", err);
+    }
+  }
+
+  window.guessStep4Storage = {
+    storeContacts: storeContacts,
+    loadContacts: loadContacts,
+    clearContacts: clearContacts,
+    storeSelectedColumns: storeSelectedColumns,
+    loadSelectedColumns: loadSelectedColumns,
+    clearSelectedColumns: clearSelectedColumns,
+  };
+})(window);

--- a/frontend/js/generate_contacts/guess_method/step4/ui.js
+++ b/frontend/js/generate_contacts/guess_method/step4/ui.js
@@ -1,0 +1,118 @@
+(function (window, $) {
+  "use strict";
+
+  const Shared = window.guessStep4Shared;
+  const Constants = window.guessStep4Constants;
+
+  function fallbackCopy(text) {
+    const temp = $("<textarea>");
+    $("body").append(temp);
+    temp.val(text).select();
+    document.execCommand("copy");
+    temp.remove();
+  }
+
+  function copyTableToClipboard(selector) {
+    const table = $(selector);
+    if (!table.length) {
+      alert("No data to copy.");
+      return;
+    }
+
+    const rows = [];
+    table.find("tr").each(function () {
+      const cols = [];
+      $(this)
+        .find("th,td")
+        .each(function () {
+          cols.push($(this).text());
+        });
+      rows.push(cols.join("\t"));
+    });
+
+    const tsv = rows.join("\n");
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(tsv).catch(function () {
+        fallbackCopy(tsv);
+      });
+    } else {
+      fallbackCopy(tsv);
+    }
+  }
+
+  function renderContactsTable(containerSelector, rows, selectedColumns, columnLabels) {
+    const container = $(containerSelector);
+    if (!Array.isArray(selectedColumns) || !selectedColumns.length) {
+      container.html('<div class="guess-step4-empty">Select at least one column to view results.</div>');
+      return;
+    }
+
+    let html = '<table id="guess-step4-results-table"><thead><tr>';
+    selectedColumns.forEach(function (column) {
+      const heading = columnLabels[column] || Shared.formatColumnLabel(column);
+      html += "<th>" + heading + "</th>";
+    });
+    html += "</tr></thead><tbody>";
+
+    rows.forEach(function (row) {
+      html += "<tr>";
+      selectedColumns.forEach(function (column) {
+        const value = row[column];
+        html += "<td>" + (value !== undefined && value !== null ? value : "") + "</td>";
+      });
+      html += "</tr>";
+    });
+
+    html += "</tbody></table>";
+    container.html(html);
+  }
+
+  function renderColumnControls(columns, selectedColumns, columnLabels, onToggleChange) {
+    const wrapper = $(Constants.COLUMN_CONTROLS_WRAPPER);
+    const container = $(Constants.COLUMN_TOGGLE_CONTAINER);
+    container.empty();
+
+    if (!Array.isArray(columns) || !columns.length) {
+      wrapper.hide();
+      return;
+    }
+
+    wrapper.css("display", "flex");
+
+    columns.forEach(function (column) {
+      const isChecked = selectedColumns.indexOf(column) !== -1;
+      const labelText = columnLabels[column] || Shared.formatColumnLabel(column);
+      const safeId = "guess-step4-col-" + String(column).replace(/[^a-zA-Z0-9]+/g, "-").toLowerCase();
+
+      const $label = $("<label>").addClass("guess-step4-toggle");
+      const $input = $("<input>")
+        .attr("type", "checkbox")
+        .attr("id", safeId)
+        .attr("data-column", column)
+        .prop("checked", isChecked);
+      const $slider = $("<span>").addClass("guess-step4-toggle-slider").attr("aria-hidden", "true");
+      const $text = $("<span>").addClass("guess-step4-toggle-label").text(labelText);
+
+      $input.on("change", function () {
+        if (typeof onToggleChange === "function") {
+          onToggleChange(column, $(this).is(":checked"), this);
+        }
+      });
+
+      $label.append($input, $slider, $text);
+      container.append($label);
+    });
+  }
+
+  function showEmptyState(message) {
+    $("#guess-step4-container").html(message || "No contacts available");
+  }
+
+  window.guessStep4UI = {
+    copyTableToClipboard: copyTableToClipboard,
+    renderContactsTable: renderContactsTable,
+    renderColumnControls: renderColumnControls,
+    showEmptyState: showEmptyState,
+  };
+})(window, window.jQuery);


### PR DESCRIPTION
## Summary
- add Populate Emails and Clear Contents controls to the Step 4 UI
- generate email variations with email/email_pattern columns and update default column selection
- provide utilities to sanitize domains/names and reset stored Step 4 results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d18637da548333927c5b6aa62944c1