### PR TITLE
Add validate emails workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from backend.find_businesses import (
     step2_bp as find_step2_bp,
     step3_bp as find_step3_bp,
 )
+from backend.validate_emails import validate_emails_bp
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -45,6 +46,7 @@ def create_app():
     app.register_blueprint(find_step1_bp)
     app.register_blueprint(find_step2_bp)
     app.register_blueprint(find_step3_bp)
+    app.register_blueprint(validate_emails_bp)
     app.register_blueprint(prioritize_step1_bp)
     app.register_blueprint(prioritize_step2_bp)
     app.register_blueprint(prioritize_step3_bp)

--- a/backend/validate_emails/__init__.py
+++ b/backend/validate_emails/__init__.py
@@ -1,0 +1,5 @@
+"""Blueprint registration for the validate emails feature."""
+
+from .routes import validate_emails_bp
+
+__all__ = ["validate_emails_bp"]

--- a/backend/validate_emails/data_store.py
+++ b/backend/validate_emails/data_store.py
@@ -1,0 +1,8 @@
+"""Simple in-memory storage for uploaded data used by the validate emails page."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# Module level DataFrame used to persist data between requests for this feature.
+DATAFRAME: pd.DataFrame | None = None

--- a/backend/validate_emails/routes.py
+++ b/backend/validate_emails/routes.py
@@ -1,0 +1,148 @@
+"""Routes supporting the validate emails workflow."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from collections import Counter
+from typing import Any
+
+import pandas as pd
+import requests
+from flask import Blueprint, jsonify, render_template, request
+
+from . import data_store
+
+API_URL = "https://verify.gmass.co/verify"
+
+validate_emails_bp = Blueprint("validate_emails", __name__)
+
+
+def _resolve_email_column(df: pd.DataFrame, requested_column: str | None) -> str | None:
+    """Return the column to use for email addresses, if available."""
+
+    if df.empty:
+        return None
+
+    if requested_column and requested_column in df.columns:
+        return requested_column
+
+    for column in df.columns:
+        if column.lower() == "email":
+            return column
+
+    return None
+
+
+def _serialize_result(result: dict[str, Any]) -> str:
+    """Serialize the GMass API response for storage inside the DataFrame."""
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+@validate_emails_bp.route("/validate_emails")
+def page() -> str:
+    """Render the validate emails page."""
+
+    return render_template("validate_emails.html")
+
+
+@validate_emails_bp.route("/validate_emails/upload", methods=["POST"])
+def upload() -> tuple[str, int] | str:
+    """Load TSV data sent from the client and store it for later processing."""
+
+    tsv_text = request.form.get("tsv_text", "").strip()
+    if not tsv_text:
+        return "No TSV data provided", 400
+
+    data_frame = pd.read_csv(io.StringIO(tsv_text), sep="\t", index_col=None)
+    data_store.DATAFRAME = data_frame
+    return data_frame.to_json(orient="records")
+
+
+@validate_emails_bp.route("/validate_emails/validate", methods=["POST"])
+def validate_emails() -> tuple[Any, int] | Any:
+    """Validate email addresses using the GMass verification API."""
+
+    if data_store.DATAFRAME is None:
+        return jsonify({"error": "No data loaded"}), 400
+
+    payload = request.get_json(silent=True) or {}
+    requested_column = payload.get("column") if isinstance(payload, dict) else None
+
+    data_frame = data_store.DATAFRAME
+    column = _resolve_email_column(data_frame, requested_column)
+    if column is None:
+        return (
+            jsonify(
+                {
+                    "error": "Email column not found",
+                    "columns": list(data_frame.columns),
+                }
+            ),
+            400,
+        )
+
+    api_key = os.getenv("GMASS_API_KEY")
+    if not api_key:
+        return jsonify({"error": "GMASS_API_KEY is not configured"}), 500
+
+    results: list[dict[str, Any]] = []
+    status_counter: Counter[str] = Counter()
+    valid_counter: Counter[str] = Counter()
+
+    for _, value in data_frame[column].fillna("").items():
+        email = str(value).strip()
+        if not email:
+            result: dict[str, Any] = {
+                "Success": False,
+                "Valid": False,
+                "Status": "EmptyEmail",
+            }
+        else:
+            try:
+                response = requests.get(
+                    API_URL,
+                    params={"email": email, "key": api_key},
+                    timeout=30,
+                )
+                response.raise_for_status()
+                result = response.json()
+            except (requests.RequestException, ValueError) as exc:
+                result = {
+                    "Success": False,
+                    "Valid": False,
+                    "Status": "RequestError",
+                    "Error": str(exc),
+                }
+
+        results.append(result)
+        status = str(result.get("Status") or "Unknown")
+        status_counter[status] += 1
+        valid_value = result.get("Valid")
+        if valid_value is True:
+            valid_counter["valid"] += 1
+        elif valid_value is False:
+            valid_counter["invalid"] += 1
+        else:
+            valid_counter["unknown"] += 1
+
+    serialized_results = [_serialize_result(result) for result in results]
+    data_frame = data_frame.copy()
+    data_frame["email_verification"] = serialized_results
+    data_store.DATAFRAME = data_frame
+
+    summary = {
+        "total": len(results),
+        "status_counts": dict(status_counter),
+        "validity_counts": dict(valid_counter),
+        "selected_column": column,
+    }
+
+    return jsonify(
+        {
+            "records": data_frame.to_dict(orient="records"),
+            "summary": summary,
+        }
+    )

--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -21,6 +21,7 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
      <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
  </nav>
 

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -171,6 +171,7 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
      <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
  </nav>
 

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -17,6 +17,7 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
      <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
  </nav>
  <p>Welcome to SFA Lead Generator.</p>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -18,6 +18,7 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
      <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
  </nav>
 

--- a/frontend/html/prioritize_businesses.html
+++ b/frontend/html/prioritize_businesses.html
@@ -21,6 +21,7 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
      <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
  </nav>
 

--- a/frontend/html/validate_emails.html
+++ b/frontend/html/validate_emails.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Validate Emails</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <style>
+        table { border-collapse: collapse; margin-top: 1em; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+        textarea { width: 100%; height: 150px; }
+        .scrollable-output {
+            max-height: 300px;
+            overflow-y: auto;
+        }
+        #validation-summary {
+            margin-top: 1em;
+            padding: 0.75em 1em;
+            background-color: #f8f9fa;
+            border: 1px solid #dfe1e5;
+            border-radius: 0.5em;
+        }
+        #validation-summary h3 {
+            margin-top: 0;
+        }
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+<h1>Validate Emails</h1>
+ <nav>
+     <a href="{{ url_for('step1.index') }}">Home</a> |
+     <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
+     <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
+     <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+ </nav>
+
+<div id="step1">
+    <h2>STEP 1: Initial Data Load</h2>
+    <form id="upload-form" method="post" enctype="multipart/form-data">
+        <label for="tsv-input">Paste TSV Data:</label><br>
+        <textarea name="tsv_text" id="tsv-input"></textarea><br>
+        <button type="submit">Load Data</button>
+        <button type="button" id="clear-step1">Clear Step 1</button>
+    </form>
+
+    <div id="table-container" class="scrollable-output"></div>
+</div>
+
+<div id="step2" style="margin-top:2em;">
+    <h2>STEP 2: Validate Emails</h2>
+    <p id="using-email-column" class="hidden"></p>
+    <div id="email-column-selector" class="hidden">
+        <label for="email-column">Select the column that contains email addresses:</label><br>
+        <select id="email-column"></select>
+    </div>
+    <button type="button" id="validate-emails-btn" disabled>Validate Emails</button>
+    <div id="validation-status" style="margin-top:1em;"></div>
+    <div id="validation-summary" class="hidden"></div>
+</div>
+
+<script src="{{ url_for('static', filename='validate_emails/step1.js') }}"></script>
+<script src="{{ url_for('static', filename='validate_emails/step2.js') }}"></script>
+</body>
+</html>

--- a/frontend/js/validate_emails/step1.js
+++ b/frontend/js/validate_emails/step1.js
@@ -1,0 +1,119 @@
+const VALIDATE_EMAILS_STORAGE_KEYS = {
+  tsv: "validate_emails_step1_tsv",
+};
+
+const validateEmailsState = {
+  data: [],
+  columns: [],
+};
+
+function renderValidateEmailsTable(data) {
+  if (!data || !data.length) {
+    $("#table-container").html("No rows");
+    return;
+  }
+
+  let html = "<table><thead><tr><th>index</th>";
+  Object.keys(data[0]).forEach((column) => {
+    html += `<th>${column}</th>`;
+  });
+  html += "</tr></thead><tbody>";
+
+  data.forEach((row, index) => {
+    html += `<tr><td>${index}</td>`;
+    Object.values(row).forEach((value) => {
+      const cellValue = value === null || value === undefined ? "" : value;
+      html += `<td>${cellValue}</td>`;
+    });
+    html += "</tr>";
+  });
+
+  html += "</tbody></table>";
+  $("#table-container").html(html);
+}
+
+function handleValidateEmailsDataLoaded(data) {
+  validateEmailsState.data = Array.isArray(data) ? data : [];
+  validateEmailsState.columns = validateEmailsState.data.length
+    ? Object.keys(validateEmailsState.data[0])
+    : [];
+
+  renderValidateEmailsTable(validateEmailsState.data);
+  $(document).trigger("validateEmails:dataLoaded", [validateEmailsState]);
+}
+
+function saveStep1State() {
+  localStorage.setItem(
+    VALIDATE_EMAILS_STORAGE_KEYS.tsv,
+    $("#tsv-input").val()
+  );
+}
+
+function autoPopulateFromSaved() {
+  const savedTsv =
+    localStorage.getItem(VALIDATE_EMAILS_STORAGE_KEYS.tsv) || "";
+  if (!savedTsv) {
+    return;
+  }
+
+  $("#tsv-input").val(savedTsv);
+
+  const formData = new FormData();
+  formData.append("tsv_text", savedTsv);
+
+  $.ajax({
+    url: "/validate_emails/upload",
+    method: "POST",
+    data: formData,
+    processData: false,
+    contentType: false,
+    success: function (response) {
+      const parsed = JSON.parse(response);
+      handleValidateEmailsDataLoaded(parsed);
+    },
+    error: function (xhr) {
+      console.error(xhr.responseText || "Failed to load saved data.");
+    },
+  });
+}
+
+$(document).ready(function () {
+  autoPopulateFromSaved();
+
+  $("#tsv-input").on("input", function () {
+    saveStep1State();
+  });
+
+  $("#upload-form").on("submit", function (event) {
+    event.preventDefault();
+
+    const formData = new FormData(this);
+
+    $.ajax({
+      url: "/validate_emails/upload",
+      method: "POST",
+      data: formData,
+      processData: false,
+      contentType: false,
+      success: function (response) {
+        const parsed = JSON.parse(response);
+        handleValidateEmailsDataLoaded(parsed);
+        saveStep1State();
+      },
+      error: function (xhr) {
+        alert(xhr.responseText || "Failed to load data.");
+      },
+    });
+  });
+
+  $("#clear-step1").on("click", function () {
+    $("#tsv-input").val("");
+    $("#table-container").empty();
+    localStorage.removeItem(VALIDATE_EMAILS_STORAGE_KEYS.tsv);
+    handleValidateEmailsDataLoaded([]);
+  });
+});
+
+window.validateEmailsState = validateEmailsState;
+window.handleValidateEmailsDataLoaded = handleValidateEmailsDataLoaded;
+window.renderValidateEmailsTable = renderValidateEmailsTable;

--- a/frontend/js/validate_emails/step2.js
+++ b/frontend/js/validate_emails/step2.js
@@ -1,0 +1,150 @@
+let selectedEmailColumn = null;
+
+function updateEmailColumnControls(state) {
+  const columns = state && Array.isArray(state.columns) ? state.columns : [];
+  const hasData = state && Array.isArray(state.data) && state.data.length > 0;
+
+  const $selectorContainer = $("#email-column-selector");
+  const $selector = $("#email-column");
+  const $usingColumn = $("#using-email-column");
+  const $validateButton = $("#validate-emails-btn");
+  const $status = $("#validation-status");
+  const $summary = $("#validation-summary");
+
+  if (!hasData) {
+    selectedEmailColumn = null;
+    $selectorContainer.addClass("hidden");
+    $usingColumn.addClass("hidden").text("");
+    $validateButton.prop("disabled", true);
+    $status.empty();
+    $summary.addClass("hidden").empty();
+    return;
+  }
+
+  $selector.empty();
+  columns.forEach((column) => {
+    $selector.append(
+      $("<option></option>").attr("value", column).text(column)
+    );
+  });
+
+  const emailMatch = columns.find((column) => column.toLowerCase() === "email");
+  if (emailMatch) {
+    selectedEmailColumn = emailMatch;
+    $selector.val(emailMatch);
+    $selectorContainer.addClass("hidden");
+    $usingColumn
+      .removeClass("hidden")
+      .text(`Using column: ${selectedEmailColumn}`);
+  } else {
+    selectedEmailColumn = columns[0] || null;
+    $selectorContainer.removeClass("hidden");
+    $usingColumn.addClass("hidden").text("");
+    if (selectedEmailColumn) {
+      $selector.val(selectedEmailColumn);
+    }
+  }
+
+  $validateButton.prop("disabled", !selectedEmailColumn);
+  $status.empty();
+}
+
+function renderValidationSummary(summary) {
+  if (!summary) {
+    $("#validation-summary").addClass("hidden").empty();
+    return;
+  }
+
+  const statusEntries = Object.entries(summary.status_counts || {});
+  const validityEntries = Object.entries(summary.validity_counts || {});
+
+  let html = "<h3>Validation Summary</h3>";
+  html += `<p><strong>Total processed:</strong> ${summary.total}</p>`;
+  if (statusEntries.length) {
+    html += "<p><strong>Status breakdown:</strong></p><ul>";
+    statusEntries.forEach(([status, count]) => {
+      html += `<li>${status}: ${count}</li>`;
+    });
+    html += "</ul>";
+  }
+  if (validityEntries.length) {
+    html += "<p><strong>Validity breakdown:</strong></p><ul>";
+    validityEntries.forEach(([key, count]) => {
+      html += `<li>${key}: ${count}</li>`;
+    });
+    html += "</ul>";
+  }
+  if (summary.selected_column) {
+    html += `<p><strong>Email column:</strong> ${summary.selected_column}</p>`;
+  }
+
+  $("#validation-summary").removeClass("hidden").html(html);
+}
+
+$(document).on("validateEmails:dataLoaded", function (_event, state) {
+  updateEmailColumnControls(state || {});
+});
+
+$("#email-column").on("change", function () {
+  selectedEmailColumn = $(this).val();
+  $("#validate-emails-btn").prop("disabled", !selectedEmailColumn);
+});
+
+$("#validate-emails-btn").on("click", function () {
+  if (!selectedEmailColumn) {
+    $("#validation-status").text(
+      "Please select the column that contains email addresses."
+    );
+    return;
+  }
+
+  const $button = $(this);
+  $button.prop("disabled", true).text("Validating…");
+  $("#validation-status").text("Validating email addresses…");
+
+  $.ajax({
+    url: "/validate_emails/validate",
+    method: "POST",
+    contentType: "application/json",
+    dataType: "json",
+    data: JSON.stringify({ column: selectedEmailColumn }),
+    success: function (response) {
+      if (response && response.records) {
+        window.handleValidateEmailsDataLoaded(response.records);
+      }
+      if (response && response.summary) {
+        renderValidationSummary(response.summary);
+      }
+      $("#validation-status").text("Validation completed.");
+    },
+    error: function (xhr) {
+      let message = "Failed to validate email addresses.";
+      let responseJson = xhr.responseJSON;
+      if (!responseJson && xhr.responseText) {
+        try {
+          responseJson = JSON.parse(xhr.responseText);
+        } catch (err) {
+          responseJson = null;
+        }
+      }
+
+      if (responseJson && responseJson.error) {
+        message = responseJson.error;
+      }
+      $("#validation-status").text(message);
+
+      if (responseJson && Array.isArray(responseJson.columns)) {
+        updateEmailColumnControls({
+          columns: responseJson.columns,
+          data:
+            window.validateEmailsState && window.validateEmailsState.data
+              ? window.validateEmailsState.data
+              : [],
+        });
+      }
+    },
+    complete: function () {
+      $button.prop("disabled", !selectedEmailColumn).text("Validate Emails");
+    },
+  });
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 pandas
 openai
+requests
 python-dotenv
 


### PR DESCRIPTION
## Summary
- add a validate-emails blueprint backed by the GMass verification API
- build a two-step front-end page for loading TSV data and validating email addresses
- update navigation links and dependencies to expose the new workflow

## Testing
- python -m compileall backend/validate_emails

------
https://chatgpt.com/codex/tasks/task_e_68d19b73a3048333b1404dded27d73d4