### PR TITLE
Add batched email validation API and frontend handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from backend.find_businesses import (
     step2_bp as find_step2_bp,
     step3_bp as find_step3_bp,
 )
+from backend.validate_emails import validate_emails_bp
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -54,6 +55,7 @@ def create_app():
     app.register_blueprint(gc_guess_step1_bp)
     app.register_blueprint(gc_guess_step2_bp)
     app.register_blueprint(gc_guess_step3_bp)
+    app.register_blueprint(validate_emails_bp)
 
     return app
 

--- a/backend/validate_emails/__init__.py
+++ b/backend/validate_emails/__init__.py
@@ -1,0 +1,3 @@
+from .routes import validate_emails_bp
+
+__all__ = ["validate_emails_bp"]

--- a/backend/validate_emails/data_store.py
+++ b/backend/validate_emails/data_store.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+_STATE: Dict[str, Any] = {
+    "dataset": [],
+    "results": {},
+    "total": None,
+}
+
+
+def reset() -> None:
+    """Clear all stored data."""
+    _STATE["dataset"] = []
+    _STATE["results"] = {}
+    _STATE["total"] = None
+
+
+def set_dataset(rows: Iterable[Any], total: Optional[int] = None) -> None:
+    """Persist the dataset that will be validated."""
+    _STATE["dataset"] = list(rows)
+    _STATE["results"] = {}
+    _STATE["total"] = len(_STATE["dataset"]) if total is None else total
+
+
+def get_dataset() -> List[Any]:
+    return list(_STATE.get("dataset", []))
+
+
+def upsert_results(entries: Dict[int, Any]) -> None:
+    stored = _STATE.setdefault("results", {})
+    for raw_index, payload in entries.items():
+        try:
+            index = int(raw_index)
+        except (TypeError, ValueError):
+            continue
+        stored[index] = payload
+
+
+def get_results() -> Dict[int, Any]:
+    return dict(_STATE.get("results", {}))
+
+
+def set_total(total: Optional[int]) -> None:
+    _STATE["total"] = total
+
+
+def get_total() -> Optional[int]:
+    total = _STATE.get("total")
+    if total is None:
+        dataset = _STATE.get("dataset") or []
+        if dataset:
+            return len(dataset)
+    return total
+
+
+def get_progress(total_override: Optional[int] = None) -> Dict[str, Any]:
+    if total_override is not None:
+        set_total(total_override)
+    total = get_total()
+    results = _STATE.get("results", {})
+    processed = len(results)
+    remaining = None
+    complete = False
+    if total is not None:
+        remaining = max(total - processed, 0)
+        complete = processed >= total
+    return {
+        "total": total,
+        "processed": processed,
+        "remaining": remaining,
+        "complete": complete,
+    }

--- a/backend/validate_emails/routes.py
+++ b/backend/validate_emails/routes.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+from flask import Blueprint, jsonify, request
+
+from . import data_store
+
+validate_emails_bp = Blueprint(
+    "validate_emails", __name__, url_prefix="/validate_emails"
+)
+
+EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _to_string(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _extract_email_from_row(row: Any) -> str:
+    if row is None:
+        return ""
+    if isinstance(row, str):
+        return row.strip()
+    if isinstance(row, (list, tuple)):
+        for item in row:
+            candidate = _extract_email_from_row(item)
+            if candidate:
+                return candidate
+        return ""
+    if isinstance(row, dict):
+        if "email" in row:
+            return _to_string(row["email"])
+        if "Email" in row:
+            return _to_string(row["Email"])
+        for key, value in row.items():
+            if "email" in key.lower():
+                candidate = _extract_email_from_row(value)
+                if candidate:
+                    return candidate
+    return ""
+
+
+def _build_partial_dataset_from_indexes(
+    start: int, stop: int
+) -> List[Dict[str, Any]]:
+    dataset = data_store.get_dataset()
+    stop = min(stop, len(dataset))
+    subset: List[Dict[str, Any]] = []
+    for index in range(start, stop):
+        subset.append({"index": index, "value": _extract_email_from_row(dataset[index])})
+    return subset
+
+
+def _validate_single(email_value: Any) -> Dict[str, Any]:
+    email = _to_string(email_value)
+    if not email:
+        return {
+            "email": email,
+            "status": "missing",
+            "reason": "No email provided",
+        }
+
+    if not EMAIL_REGEX.match(email):
+        return {
+            "email": email,
+            "status": "invalid",
+            "reason": "Email format is invalid",
+        }
+
+    local_part, domain = email.split("@", 1)
+    if not local_part or not domain:
+        return {
+            "email": email,
+            "status": "invalid",
+            "reason": "Email format is invalid",
+        }
+
+    if domain.startswith("-") or domain.endswith("-"):
+        return {
+            "email": email,
+            "status": "invalid",
+            "reason": "Domain format appears invalid",
+        }
+
+    return {
+        "email": email,
+        "status": "valid",
+        "reason": "Address format looks correct",
+        "domain": domain.lower(),
+    }
+
+
+def _prepare_payload_entries(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    emails: Optional[Iterable[Any]] = payload.get("emails")
+    if emails is None:
+        start = payload.get("start")
+        stop = payload.get("stop")
+        if start is not None and stop is not None:
+            try:
+                start_int = int(start)
+                stop_int = int(stop)
+            except (TypeError, ValueError):
+                raise ValueError("start and stop must be integers")
+            if stop_int <= start_int:
+                raise ValueError("stop must be greater than start")
+            emails = _build_partial_dataset_from_indexes(start_int, stop_int)
+        else:
+            emails = []
+
+    prepared: List[Dict[str, Any]] = []
+    for item in emails:
+        if isinstance(item, dict):
+            index = item.get("index")
+            try:
+                index_int = int(index)
+            except (TypeError, ValueError):
+                index_int = None
+            prepared.append({
+                "index": index_int,
+                "value": item.get("value") or item.get("email"),
+            })
+        else:
+            prepared.append({"index": None, "value": item})
+    return prepared
+
+
+@validate_emails_bp.route("/validate", methods=["POST"])
+def validate_emails() -> Any:
+    payload = request.get_json(silent=True) or {}
+
+    try:
+        entries = _prepare_payload_entries(payload)
+    except ValueError as exc:  # pragma: no cover - defensive
+        return jsonify({"error": str(exc)}), 400
+
+    total_count = payload.get("total_count")
+    if total_count is not None:
+        try:
+            total_count = int(total_count)
+        except (TypeError, ValueError):
+            return jsonify({"error": "total_count must be an integer"}), 400
+
+    if payload.get("dataset"):
+        data_store.set_dataset(payload["dataset"], total=total_count)
+    elif total_count is not None:
+        data_store.set_total(total_count)
+
+    if not entries:
+        progress = data_store.get_progress(total_override=total_count)
+        return (
+            jsonify(
+                {
+                    "results": {},
+                    "progress": progress,
+                    "error": "No email entries supplied",
+                }
+            ),
+            400,
+        )
+
+    partial_results: Dict[int, Dict[str, Any]] = {}
+    for position, entry in enumerate(entries):
+        index = entry.get("index")
+        try:
+            index_int = int(index) if index is not None else None
+        except (TypeError, ValueError):
+            index_int = None
+        result = _validate_single(entry.get("value"))
+        if index_int is None:
+            index_int = -1 - position
+        result["index"] = index_int
+        partial_results[index_int] = result
+
+    data_store.upsert_results(partial_results)
+    progress = data_store.get_progress(total_override=total_count)
+
+    response_results = {str(idx): data for idx, data in partial_results.items()}
+    return jsonify({"results": response_results, "progress": progress})
+
+
+__all__ = ["validate_emails_bp"]

--- a/frontend/js/validate_emails/step2.js
+++ b/frontend/js/validate_emails/step2.js
@@ -1,0 +1,448 @@
+(function () {
+  const START_BUTTON_SELECTOR =
+    "#validate-emails-run, #validate-emails-start, #validate-emails-validate-btn, #validate-emails-process-btn";
+  const CANCEL_BUTTON_SELECTOR = "#validate-emails-cancel, #validate-emails-stop";
+  const DEFAULT_BATCH_SIZE = 20;
+  const state = (window.validateEmailsState = window.validateEmailsState || {});
+
+  state.data = Array.isArray(state.data) ? state.data : [];
+  state.results = state.results || {};
+  state.progress = state.progress || {
+    total: state.data.length || null,
+    processed: Object.keys(state.results).length,
+    remaining: null,
+    complete: false,
+  };
+
+  let isProcessing = false;
+  let cancelRequested = false;
+  let currentRequest = null;
+
+  function toNumber(value) {
+    const parsed = parseInt(value, 10);
+    return isNaN(parsed) ? null : parsed;
+  }
+
+  function setText(selector, text) {
+    if (!selector) return;
+    const el = $(selector);
+    if (!el.length) return;
+    el.text(text);
+  }
+
+  function escapeHtml(value) {
+    if (value === undefined || value === null) {
+      return "";
+    }
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function extractEmail(row) {
+    if (row === null || row === undefined) return "";
+    if (typeof row === "string") return row.trim();
+    if (Array.isArray(row)) {
+      for (let i = 0; i < row.length; i += 1) {
+        const emailCandidate = extractEmail(row[i]);
+        if (emailCandidate) return emailCandidate;
+      }
+      return "";
+    }
+    if (typeof row === "object") {
+      if (row.email) return String(row.email).trim();
+      if (row.Email) return String(row.Email).trim();
+      for (const key in row) {
+        if (!Object.prototype.hasOwnProperty.call(row, key)) continue;
+        const lower = key.toLowerCase();
+        if (lower.includes("email")) {
+          const val = row[key];
+          if (val === null || val === undefined) continue;
+          if (typeof val === "string") return val.trim();
+          const nested = extractEmail(val);
+          if (nested) return nested;
+        }
+      }
+    }
+    return "";
+  }
+
+  function getBatchSize() {
+    const input = $("#validate-emails-batch-size");
+    if (input.length) {
+      const parsed = toNumber(input.val());
+      if (parsed && parsed > 0) {
+        return parsed;
+      }
+    }
+    return DEFAULT_BATCH_SIZE;
+  }
+
+  function chunkEntries(entries, size) {
+    const batches = [];
+    for (let i = 0; i < entries.length; i += size) {
+      batches.push(entries.slice(i, i + size));
+    }
+    return batches;
+  }
+
+  function recomputeSummary() {
+    const results = state.results || {};
+    const summary = {
+      total:
+        state.progress && state.progress.total !== undefined && state.progress.total !== null
+          ? state.progress.total
+          : state.data
+          ? state.data.length
+          : null,
+      processed: 0,
+      valid: 0,
+      invalid: 0,
+      missing: 0,
+    };
+
+    Object.keys(results).forEach(function (key) {
+      if (!Object.prototype.hasOwnProperty.call(results, key)) return;
+      const entry = results[key] || {};
+      summary.processed += 1;
+      const status = (entry.status || "").toLowerCase();
+      if (status === "valid") summary.valid += 1;
+      else if (status === "invalid") summary.invalid += 1;
+      else if (status === "missing" || status === "empty") summary.missing += 1;
+    });
+
+    if (summary.total !== null && summary.total !== undefined) {
+      summary.remaining = Math.max(summary.total - summary.processed, 0);
+    } else {
+      summary.remaining = null;
+    }
+    state.summary = summary;
+    return summary;
+  }
+
+  function updateSummaryUI() {
+    if (!state.summary) return;
+    const summary = state.summary;
+    const summaryContainer = $("#validate-emails-summary");
+    if (summaryContainer.length) {
+      const parts = [];
+      if (summary.total !== null && summary.total !== undefined) {
+        parts.push("Total: " + summary.total);
+      }
+      parts.push("Processed: " + summary.processed);
+      parts.push("Valid: " + summary.valid);
+      parts.push("Invalid: " + summary.invalid);
+      parts.push("Missing: " + summary.missing);
+      if (summary.remaining !== null && summary.remaining !== undefined) {
+        parts.push("Remaining: " + summary.remaining);
+      }
+      summaryContainer.text(parts.join(" • "));
+    }
+
+    setText("#validate-emails-summary-total", summary.total !== null ? summary.total : "");
+    setText("#validate-emails-summary-processed", summary.processed);
+    setText("#validate-emails-summary-valid", summary.valid);
+    setText("#validate-emails-summary-invalid", summary.invalid);
+    setText("#validate-emails-summary-missing", summary.missing);
+    if (summary.remaining !== null && summary.remaining !== undefined) {
+      setText("#validate-emails-summary-remaining", summary.remaining);
+    }
+  }
+
+  function renderResultsTable() {
+    const table = $("#validate-emails-results");
+    if (!table.length) return;
+    let tbody = table.find("tbody");
+    if (!tbody.length) {
+      tbody = $("<tbody></tbody>");
+      table.append(tbody);
+    }
+
+    const rows = [];
+    const keys = Object.keys(state.results || {}).sort(function (a, b) {
+      return (parseInt(a, 10) || 0) - (parseInt(b, 10) || 0);
+    });
+
+    keys.forEach(function (key) {
+      if (!Object.prototype.hasOwnProperty.call(state.results, key)) return;
+      const entry = state.results[key] || {};
+      rows.push(
+        "<tr>" +
+          '<td class="index">' + escapeHtml(key) + "</td>" +
+          '<td class="email">' + escapeHtml(entry.email || "") + "</td>" +
+          '<td class="status">' + escapeHtml(entry.status || "") + "</td>" +
+          '<td class="detail">' + escapeHtml(entry.reason || entry.message || entry.detail || "") + "</td>" +
+          "</tr>"
+      );
+    });
+
+    tbody.html(rows.join(""));
+  }
+
+  function updateProgressUI(progress) {
+    state.progress = state.progress || {};
+    if (progress) {
+      if (progress.total !== undefined) state.progress.total = progress.total;
+      if (progress.processed !== undefined) state.progress.processed = progress.processed;
+      if (progress.remaining !== undefined) state.progress.remaining = progress.remaining;
+      if (progress.complete !== undefined) state.progress.complete = !!progress.complete;
+    } else {
+      state.progress.processed = Object.keys(state.results || {}).length;
+      if (state.summary && state.summary.remaining !== undefined) {
+        state.progress.remaining = state.summary.remaining;
+      }
+    }
+
+    const summary = state.summary || recomputeSummary();
+    if (state.progress.total === null || state.progress.total === undefined) {
+      state.progress.total = summary.total;
+    }
+    if (state.progress.remaining === null || state.progress.remaining === undefined) {
+      state.progress.remaining = summary.remaining;
+    }
+    state.progress.processed = summary.processed;
+
+    const progressTextParts = [];
+    if (state.progress.total !== null && state.progress.total !== undefined) {
+      progressTextParts.push(state.progress.processed + " / " + state.progress.total);
+    } else {
+      progressTextParts.push(state.progress.processed + " processed");
+    }
+    if (state.progress.remaining !== null && state.progress.remaining !== undefined) {
+      progressTextParts.push(state.progress.remaining + " remaining");
+    }
+    if (state.progress.complete) {
+      progressTextParts.push("Complete");
+    }
+
+    setText("#validate-emails-progress", progressTextParts.join(" • "));
+    setText("#validate-emails-progress-processed", state.progress.processed);
+    if (state.progress.total !== null && state.progress.total !== undefined) {
+      setText("#validate-emails-progress-total", state.progress.total);
+    }
+    if (state.progress.remaining !== null && state.progress.remaining !== undefined) {
+      setText("#validate-emails-progress-remaining", state.progress.remaining);
+    }
+
+    const progressBar = $("#validate-emails-progress-bar");
+    if (progressBar.length && state.progress.total) {
+      const percent = Math.min(100, Math.round((state.progress.processed / state.progress.total) * 100));
+      progressBar.css("width", percent + "%");
+      progressBar.attr("aria-valuenow", percent);
+      progressBar.attr("aria-valuemax", 100);
+    }
+  }
+
+  function toggleProcessingUI(running, currentBatch, totalBatches) {
+    const buttons = $(START_BUTTON_SELECTOR);
+    if (buttons.length) {
+      buttons.prop("disabled", !!running);
+    }
+    const cancelButtons = $(CANCEL_BUTTON_SELECTOR);
+    if (cancelButtons.length) {
+      cancelButtons.prop("disabled", !running);
+    }
+    const statusEl = $("#validate-emails-status, #validate-emails-processing-status");
+    if (statusEl.length) {
+      if (running) {
+        const label = totalBatches
+          ? "Validating batch " + currentBatch + " of " + totalBatches + "..."
+          : "Validating emails...";
+        statusEl.text(label);
+      } else if (!cancelRequested) {
+        statusEl.text("Ready");
+      } else {
+        statusEl.text("Cancelled");
+      }
+    }
+  }
+
+  function mergeBatchResults(partialResults) {
+    if (!partialResults) return recomputeSummary();
+    const keys = Object.keys(partialResults);
+    keys.forEach(function (key) {
+      if (!Object.prototype.hasOwnProperty.call(partialResults, key)) return;
+      const result = partialResults[key] || {};
+      let index = toNumber(key);
+      if (index === null && result.index !== undefined) {
+        index = toNumber(result.index);
+      }
+      const normalizedKey = index === null ? String(key) : String(index);
+      const emailFromResult = result.email || result.value;
+      const merged = Object.assign(
+        {},
+        state.results[normalizedKey] || {},
+        result,
+        {
+          index: index === null ? result.index : index,
+          email:
+            emailFromResult ||
+            (index !== null && state.data && state.data[index] ? extractEmail(state.data[index]) : emailFromResult || ""),
+        }
+      );
+      state.results[normalizedKey] = merged;
+    });
+    return recomputeSummary();
+  }
+
+  function buildEntries() {
+    const entries = [];
+    const dataset = Array.isArray(state.data) ? state.data : [];
+    for (let i = 0; i < dataset.length; i += 1) {
+      const email = extractEmail(dataset[i]);
+      entries.push({
+        index: i,
+        email: email,
+        row: dataset[i],
+      });
+    }
+    return entries;
+  }
+
+  function buildPayloadFromBatch(batch) {
+    return {
+      emails: batch.map(function (item) {
+        return {
+          index: item.index,
+          value: item.email,
+        };
+      }),
+      total_count: state.data ? state.data.length : undefined,
+    };
+  }
+
+  function sendBatchQueue(batches, pos) {
+    if (cancelRequested) {
+      isProcessing = false;
+      toggleProcessingUI(false);
+      cancelRequested = false;
+      currentRequest = null;
+      updateProgressUI();
+      updateSummaryUI();
+      return;
+    }
+
+    if (pos >= batches.length) {
+      isProcessing = false;
+      toggleProcessingUI(false);
+      state.progress.complete = true;
+      updateProgressUI({ complete: true });
+      updateSummaryUI();
+      currentRequest = null;
+      return;
+    }
+
+    toggleProcessingUI(true, pos + 1, batches.length);
+    const payload = buildPayloadFromBatch(batches[pos]);
+
+    currentRequest = $.ajax({
+      url: "/validate_emails/validate",
+      method: "POST",
+      contentType: "application/json",
+      data: JSON.stringify(payload),
+    })
+      .done(function (response) {
+        const partialResults = response && response.results ? response.results : {};
+        mergeBatchResults(partialResults);
+        if (response && response.progress) {
+          updateProgressUI(response.progress);
+        } else {
+          updateProgressUI();
+        }
+        updateSummaryUI();
+        currentRequest = null;
+        sendBatchQueue(batches, pos + 1);
+      })
+      .fail(function (xhr, textStatus) {
+        currentRequest = null;
+        if (textStatus === "abort") {
+          return;
+        }
+        console.error("Failed to validate email batch", textStatus, xhr && xhr.responseText);
+        toggleProcessingUI(false);
+        isProcessing = false;
+        cancelRequested = false;
+        let message = "Unable to validate this batch.";
+        if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+          message += " " + xhr.responseJSON.error;
+        } else if (xhr && xhr.responseText) {
+          message += " " + xhr.responseText;
+        }
+        alert(message);
+      });
+  }
+
+  function startValidation() {
+    if (isProcessing) return;
+    cancelRequested = false;
+
+    const dataset = Array.isArray(state.data) ? state.data : [];
+    if (!dataset.length) {
+      alert("No email data loaded for validation.");
+      return;
+    }
+
+    const entries = buildEntries();
+    const results = state.results || {};
+    const remainingEntries = entries.filter(function (entry) {
+      return !Object.prototype.hasOwnProperty.call(results, String(entry.index));
+    });
+
+    const batchSize = getBatchSize();
+    const batches = chunkEntries(remainingEntries, batchSize);
+
+    if (!batches.length) {
+      state.progress.complete = true;
+      updateProgressUI({ complete: true });
+      updateSummaryUI();
+      alert("All rows have already been validated.");
+      return;
+    }
+
+    isProcessing = true;
+    state.progress.complete = false;
+    updateProgressUI({ total: dataset.length });
+    updateSummaryUI();
+    sendBatchQueue(batches, 0);
+  }
+
+  function cancelValidation() {
+    if (!isProcessing) return;
+    cancelRequested = true;
+    if (currentRequest && currentRequest.readyState !== 4) {
+      currentRequest.abort();
+    }
+    toggleProcessingUI(false);
+  }
+
+  function bindEventHandlers() {
+    $(START_BUTTON_SELECTOR)
+      .off("click.validateEmails")
+      .on("click.validateEmails", function (event) {
+        event.preventDefault();
+        startValidation();
+      });
+
+    $(CANCEL_BUTTON_SELECTOR)
+      .off("click.validateEmailsCancel")
+      .on("click.validateEmailsCancel", function (event) {
+        event.preventDefault();
+        cancelValidation();
+      });
+  }
+
+  function initialise() {
+    bindEventHandlers();
+    recomputeSummary();
+    updateSummaryUI();
+    updateProgressUI();
+    renderResultsTable();
+  }
+
+  $(document).ready(function () {
+    initialise();
+  });
+})();


### PR DESCRIPTION
## Summary
- add a validate_emails blueprint that validates supplied email subsets and reports progress while persisting results
- store intermediate validation data in a dedicated in-memory data store to support incremental batching
- update the step 2 frontend script to send sequential batched requests, merge partial responses, and refresh progress indicators

## Testing
- python -m compileall backend frontend/js/validate_emails/step2.js

------
https://chatgpt.com/codex/tasks/task_e_68d1a419e9c4833385057ce5bbec469d