### PR TITLE
Move Validate Emails nav link and default to Guess method

### DIFF
--- a/frontend/html/find_businesses.html
+++ b/frontend/html/find_businesses.html
@@ -21,8 +21,8 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
-     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
-     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a>
  </nav>
 
 <div id="step1">

--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -171,17 +171,17 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
-     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
-     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a>
  </nav>
 
 <div class="method-toggle">
-    <button type="button" class="method-tab active" data-target="simple-method">Simple Method</button>
-    <button type="button" class="method-tab" data-target="guess-method">Guess Method</button>
+    <button type="button" class="method-tab" data-target="simple-method">Simple Method</button>
+    <button type="button" class="method-tab active" data-target="guess-method">Guess Method</button>
 </div>
 
 <div class="method-content">
-    <section id="simple-method" class="method-section active" aria-hidden="false">
+    <section id="simple-method" class="method-section" aria-hidden="true">
         <div id="step1">
             <h2>STEP 1: Initial Data Load</h2>
             <form id="upload-form" method="post" enctype="multipart/form-data">
@@ -225,7 +225,7 @@
         </div>
     </section>
 
-    <section id="guess-method" class="method-section" aria-hidden="true">
+    <section id="guess-method" class="method-section active" aria-hidden="false">
         <div id="guess-step1">
             <h2>STEP 1: Initial Data Load</h2>
             <form id="guess-upload-form" method="post" enctype="multipart/form-data">

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -17,8 +17,8 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
-     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
-     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a>
  </nav>
  <p>Welcome to SFA Lead Generator.</p>
 </body>

--- a/frontend/html/parse_locations.html
+++ b/frontend/html/parse_locations.html
@@ -18,8 +18,8 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
-     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
-     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a>
  </nav>
 
 <div id="step1">

--- a/frontend/html/prioritize_businesses.html
+++ b/frontend/html/prioritize_businesses.html
@@ -21,8 +21,8 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
-     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
-     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a>
  </nav>
 
 <div id="step1">

--- a/frontend/html/validate_emails.html
+++ b/frontend/html/validate_emails.html
@@ -37,8 +37,8 @@
      <a href="{{ url_for('parse_locations.parse_locations') }}">Parse Locations</a> |
      <a href="{{ url_for('find_businesses.find_businesses') }}">Find Businesses</a> |
      <a href="{{ url_for('prioritize_businesses.prioritize_businesses') }}">Prioritize Businesses</a> |
-     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a> |
-     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a>
+     <a href="{{ url_for('step1.generate_contacts') }}">Generate Contacts</a> |
+     <a href="{{ url_for('validate_emails.page') }}">Validate Emails</a>
  </nav>
 
 <div id="step1">


### PR DESCRIPTION
## Summary
- reposition the Validate Emails navigation link to the end of the menu on every page
- default the Generate Contacts view to show the Guess Method tab on load

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d20d77454c83338a38d14a543c1e05