### PR TITLE
Enable inline editing for guess step 2 results

### DIFF
--- a/frontend/html/generate_contacts.html
+++ b/frontend/html/generate_contacts.html
@@ -276,6 +276,7 @@
                 <button id="guess-process-range-btn">Process Range</button>
                 <button type="button" id="guess-extract-domain-btn">Extract Domains</button>
                 <button type="button" id="guess-cancel-step2">Cancel Processing</button>
+                <button type="button" id="guess-save-step2-edits">Save Edits</button>
                 <button type="button" id="guess-clear-step2">Clear Results</button>
             </div>
             <div id="guess-results-container" class="scrollable-output" style="margin-top:1em;"></div>

--- a/frontend/js/generate_contacts/guess_method/step2.js
+++ b/frontend/js/generate_contacts/guess_method/step2.js
@@ -3,6 +3,7 @@
   const SHARED_PROMPT_KEY = "generate_contacts_guess_shared_prompt";
   const STEP3_INSTRUCTIONS_KEY = "generate_contacts_guess_step3_instructions";
   const STEP3_RESULTS_KEY = "generate_contacts_guess_step3_results";
+  const STEP4_CONTACTS_KEY = "generate_contacts_guess_step4_contacts";
   const MODE_STORAGE_KEY = "generate_contacts_guess_process_mode";
   const LEGACY_PROMPT_KEYS = [
     "generate_contacts_guess_step2_prompt",
@@ -260,6 +261,7 @@
     window.guessStep2Results = stepResults;
     localStorage.setItem(RESULTS_KEY, JSON.stringify(stepResults));
     localStorage.removeItem(STEP3_RESULTS_KEY);
+    localStorage.removeItem(STEP4_CONTACTS_KEY);
     $(document).trigger("guessStep2ResultsUpdated", [stepResults]);
   }
 
@@ -490,6 +492,7 @@
     stepResults = replaceStepResults({});
     localStorage.removeItem(RESULTS_KEY);
     localStorage.removeItem(STEP3_RESULTS_KEY);
+    localStorage.removeItem(STEP4_CONTACTS_KEY);
     $("#guess-results-container").html("No results");
     $(document).trigger("guessStep2ResultsUpdated", [stepResults]);
   });

--- a/frontend/js/generate_contacts/guess_method/step4.js
+++ b/frontend/js/generate_contacts/guess_method/step4.js
@@ -13,6 +13,31 @@
   const STALE_CONTACTS_MESSAGE =
     "Step 2 results changed. Generate contacts again to view updates.";
 
+  function flushPendingStep2Edit() {
+    const activeElement = document.activeElement;
+    if (!activeElement) {
+      return Promise.resolve();
+    }
+
+    const $active = $(activeElement);
+    const isEditableCell =
+      $active.length &&
+      $active.is("td[data-column]") &&
+      $active.closest("#guess-results-container").length;
+
+    if (!isEditableCell) {
+      return Promise.resolve();
+    }
+
+    if (typeof activeElement.blur === "function") {
+      activeElement.blur();
+    }
+
+    return new Promise(function (resolve) {
+      setTimeout(resolve, 0);
+    });
+  }
+
   let parsedContacts = [];
   let availableColumns = [];
   let selectedColumns = [];
@@ -209,8 +234,16 @@
   });
 
   $(function () {
-    $("#guess-create-contacts-btn").on("click", createContacts);
-    $(Constants.POPULATE_EMAILS_BUTTON).on("click", populateEmails);
+    $("#guess-create-contacts-btn").on("click", function () {
+      flushPendingStep2Edit().then(function () {
+        createContacts();
+      });
+    });
+    $(Constants.POPULATE_EMAILS_BUTTON).on("click", function () {
+      flushPendingStep2Edit().then(function () {
+        populateEmails();
+      });
+    });
     $("#guess-copy-step4-results").on("click", handleCopy);
     $(Constants.CLEAR_STEP4_BUTTON).on("click", clearStep4Results);
     loadStoredContacts();

--- a/frontend/js/generate_contacts/guess_method/step4.js
+++ b/frontend/js/generate_contacts/guess_method/step4.js
@@ -14,6 +14,14 @@
     "Step 2 results changed. Generate contacts again to view updates.";
 
   function flushPendingStep2Edit() {
+    if (typeof window.guessStep2SaveInlineEdits === "function") {
+      try {
+        window.guessStep2SaveInlineEdits();
+      } catch (err) {
+        console.error("Unable to persist Step 2 edits before Step 4 action", err);
+      }
+    }
+
     const activeElement = document.activeElement;
     if (!activeElement) {
       return Promise.resolve();

--- a/frontend/js/generate_contacts/guess_method/step4/contacts.js
+++ b/frontend/js/generate_contacts/guess_method/step4/contacts.js
@@ -4,22 +4,35 @@
   const Shared = window.guessStep4Shared;
   const Constants = window.guessStep4Constants;
 
-  function ensureStep2Results() {
-    if (window.guessStep2Results && typeof window.guessStep2Results === "object") {
+  function readStoredStep2Results() {
+    let saved = null;
+    try {
+      saved = localStorage.getItem(Constants.STEP2_RESULTS_KEY);
+    } catch (err) {
+      console.error("Unable to access stored Step 2 results", err);
+      return {};
+    }
+
+    if (!saved) {
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(saved);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch (err) {
+      console.error("Unable to parse stored Step 2 results", err);
+      return {};
+    }
+  }
+
+  function ensureStep2Results(forceReload) {
+    const shouldReload = Boolean(forceReload);
+    if (!shouldReload && window.guessStep2Results && typeof window.guessStep2Results === "object") {
       return window.guessStep2Results;
     }
 
-    const saved = localStorage.getItem(Constants.STEP2_RESULTS_KEY);
-    if (saved) {
-      try {
-        window.guessStep2Results = JSON.parse(saved);
-        return window.guessStep2Results;
-      } catch (err) {
-        console.error("Unable to parse stored Step 2 results", err);
-      }
-    }
-
-    window.guessStep2Results = {};
+    window.guessStep2Results = readStoredStep2Results();
     return window.guessStep2Results;
   }
 
@@ -75,7 +88,7 @@
   }
 
   function buildContactRows() {
-    const results = ensureStep2Results();
+    const results = ensureStep2Results(true);
     const indexes = Object.keys(results).sort(function (a, b) {
       return parseInt(a, 10) - parseInt(b, 10);
     });


### PR DESCRIPTION
## Summary
- make the Step 2 results table cells editable and tag them with their row/column metadata
- handle inline edits by persisting changes, recalculating email domains when needed, and re-rendering the table for consistent formatting

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d2b55065388333b1000abfe74fdf4a