### PR TITLE
Handle missing stored guess step results

### DIFF
--- a/frontend/js/generate_contacts/guess_method/step2.js
+++ b/frontend/js/generate_contacts/guess_method/step2.js
@@ -351,9 +351,13 @@
 
   function storeResults() {
     window.guessStep2Results = stepResults;
-    localStorage.setItem(RESULTS_KEY, JSON.stringify(stepResults));
-    localStorage.removeItem(STEP3_RESULTS_KEY);
-    localStorage.removeItem(STEP4_CONTACTS_KEY);
+    try {
+      localStorage.setItem(RESULTS_KEY, JSON.stringify(stepResults));
+      localStorage.removeItem(STEP3_RESULTS_KEY);
+      localStorage.removeItem(STEP4_CONTACTS_KEY);
+    } catch (err) {
+      console.error("Unable to persist Step 2 results", err);
+    }
     $(document).trigger("guessStep2ResultsUpdated", [stepResults]);
   }
 

--- a/frontend/js/generate_contacts/guess_method/step4/contacts.js
+++ b/frontend/js/generate_contacts/guess_method/step4/contacts.js
@@ -27,12 +27,31 @@
   }
 
   function ensureStep2Results(forceReload) {
-    const shouldReload = Boolean(forceReload);
-    if (!shouldReload && window.guessStep2Results && typeof window.guessStep2Results === "object") {
+    const hasExistingResults =
+      window.guessStep2Results && typeof window.guessStep2Results === "object";
+    if (!forceReload && hasExistingResults) {
       return window.guessStep2Results;
     }
 
-    window.guessStep2Results = readStoredStep2Results();
+    const storedResults = readStoredStep2Results();
+    const hasStoredResults =
+      storedResults && typeof storedResults === "object" && Object.keys(storedResults).length > 0;
+
+    if (hasStoredResults) {
+      window.guessStep2Results = storedResults;
+      return window.guessStep2Results;
+    }
+
+    if (hasExistingResults) {
+      if (forceReload) {
+        console.warn(
+          "Stored Step 2 results were empty; retaining in-memory results instead.",
+        );
+      }
+      return window.guessStep2Results;
+    }
+
+    window.guessStep2Results = storedResults && typeof storedResults === "object" ? storedResults : {};
     return window.guessStep2Results;
   }
 


### PR DESCRIPTION
## Summary
- avoid overwriting in-memory Step 2 results in Step 4 when the stored snapshot is empty and log a warning instead
- wrap Step 2 persistence in a try/catch so updates still propagate when localStorage is unavailable

## Testing
- not run (manual UI scenario required)


------
https://chatgpt.com/codex/tasks/task_e_68d2f1ff64048333ab9b823a9d963d9e